### PR TITLE
Fix chatbot reliability: guided-flow stalls, freezes, streaming, bulk fill, reopen

### DIFF
--- a/behav3d/napari/_assistant.py
+++ b/behav3d/napari/_assistant.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from qtpy.QtCore import Qt, QThread, Signal
+from qtpy.QtCore import Qt, QThread, QTimer, Signal
 from qtpy.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit,
     QTextBrowser, QFrame, QSizePolicy,
@@ -264,7 +264,20 @@ class AssistantDock(QWidget):
         self._pending_auto_continue: list | None = None  # deferred after _on_finished
         self._auto_continue_turns: int = 0
         self._last_auto_continue_signature: tuple | None = None
+        # Progress-based auto-continue guard: keep going as long as each turn applies a
+        # NEW distinct value; only stop after consecutive stalled turns (no new progress).
+        self._auto_continue_seen_signatures: set[tuple] = set()
+        self._auto_continue_stall_count: int = 0
         self._confirmed_parameter_keys: set[str] = set()
+        # Coalesce streamed-token re-renders. Re-rendering the whole transcript on
+        # every token saturates the GUI thread on long answers (the napari window
+        # freezes until the stream ends). This single-shot timer batches tokens into
+        # at most one render per interval; the expensive full-document style walk is
+        # applied only on the final render of the turn.
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.setInterval(90)
+        self._render_timer.timeout.connect(self._render_streaming)
 
         # Cohesive dark-theme styling for the whole dock (matches napari surfaces).
         self.setStyleSheet("""
@@ -371,25 +384,42 @@ class AssistantDock(QWidget):
     # ------------------------------------------------------------------
     # Transcript helpers
     # ------------------------------------------------------------------
-    def _render(self):
+    def _render(self, style: bool = True):
         """Re-render the whole transcript as markdown.
 
         QTextCursor.insertMarkdown does not exist in PyQt5, so we keep a log of
         markdown blocks and render the document with QTextEdit.setMarkdown (which
         does render bold/italic/lists/code), then pin the scrollbar to the bottom.
+
+        ``style=False`` skips the full-document style walk — used for the throttled
+        renders during token streaming so a long answer doesn't freeze the GUI.
         """
+        # Any direct/full render supersedes a pending throttled one.
+        self._render_timer.stop()
         blocks = list(self._md_log)
         if self._streaming_text is not None:
             blocks.append(f"**BEHAV3D Assistant**\n\n{self._streaming_text or '...'}")
         try:
             # A thin rule between turns gives clear visual separation.
             self.transcript.setMarkdown("\n\n---\n\n".join(blocks))
-            self._style_blocks()
+            if style:
+                self._style_blocks()
         except Exception:
             # Fallback for any Qt build lacking setMarkdown.
             self.transcript.setPlainText("\n\n".join(blocks))
         sb = self.transcript.verticalScrollBar()
         sb.setValue(sb.maximum())
+
+    def _render_streaming(self):
+        """Throttled render during streaming — skips the expensive style walk,
+        which is applied once when the turn finishes (_on_finished → _render)."""
+        self._render(style=False)
+
+    def _schedule_render(self):
+        """Request a render soon, coalescing bursts of streamed tokens into at
+        most one render per timer interval."""
+        if not self._render_timer.isActive():
+            self._render_timer.start()
 
     def _style_blocks(self):
         """setMarkdown renders paragraphs/lists very tightly. Walk the document
@@ -438,6 +468,8 @@ class AssistantDock(QWidget):
         if reset_auto_loop:
             self._auto_continue_turns = 0
             self._last_auto_continue_signature = None
+            self._auto_continue_seen_signatures = set()
+            self._auto_continue_stall_count = 0
         if show_as_user:
             self._append_user(display_text or text)
         self._history.append({"role": "user", "content": text})
@@ -471,7 +503,8 @@ class AssistantDock(QWidget):
 
     def _set_busy(self, busy: bool):
         self.btn_send.setEnabled(not busy)
-        self.input.setEnabled(not busy)
+        # Leave the input box editable while a turn is in flight so the user can
+        # type their next answer without waiting for the stream to finish.
         for i in range(self._quick_layout.count()):
             row = self._quick_layout.itemAt(i)
             sub = row.layout() if row else None
@@ -488,7 +521,7 @@ class AssistantDock(QWidget):
         if self._streaming_text is None:
             self._streaming_text = ""
         self._streaming_text += chunk
-        self._render()
+        self._schedule_render()
 
     def _on_degraded(self, full_text: str):
         self._streaming_text = full_text
@@ -498,6 +531,9 @@ class AssistantDock(QWidget):
         # close any open streaming block, then show the error
         self._finalize_streaming()
         self._append_md(message)
+        # Defensive: ensure the dock never stays stuck "thinking" if signal
+        # ordering ever changes (worker.finished still clears busy too).
+        self._set_busy(False)
 
     def _on_tool_calls(self, calls: list):
         try:
@@ -513,28 +549,51 @@ class AssistantDock(QWidget):
         auto_previews = []
         noop_previews = []
         had_auto = False
-        for act in actions:
-            if self._is_noop_action(act):
-                self._record_noop_action(act)
-                noop_previews.append(self._noop_preview(act))
-                continue
-            if self._should_auto_apply(act):
-                if act.ok:
-                    # Classify BEFORE applying (widget still holds pre-apply state).
-                    _silent_auto = self._is_silent_auto_apply(act)
-                    try:
-                        ok = apply_action(self.main_widget, act)
-                    except Exception:
-                        ok = False
-                    if ok:
-                        had_auto = True
-                        # Only count as a meaningful change if it wasn't a structural
-                        # trigger or a same-value no-op re-call from the model.
-                        if not _silent_auto:
-                            auto_previews.append(act.preview)
-                        self.refresh_context_bar()
-            else:
-                self._add_action_card(act)
+        # Suppress per-widget pulse glows when applying a batch — a flood of fills
+        # would otherwise schedule hundreds of QTimers and thrash stylesheets,
+        # which can freeze the GUI. One context-bar refresh happens at the end.
+        from behav3d.napari._assistant_actions import set_pulse_suppressed
+        batch = len(actions) > 1
+        if batch:
+            set_pulse_suppressed(True)
+        try:
+            for act in actions:
+                if self._is_noop_action(act):
+                    self._record_noop_action(act)
+                    noop_previews.append(self._noop_preview(act))
+                    continue
+                if self._should_auto_apply(act):
+                    if act.ok:
+                        # Classify BEFORE applying (widget still holds pre-apply state).
+                        _silent_auto = self._is_silent_auto_apply(act)
+                        try:
+                            ok = apply_action(self.main_widget, act)
+                        except Exception:
+                            ok = False
+                        if ok:
+                            had_auto = True
+                            if act.kind == "bulk_fill_metadata":
+                                n = (act.data.get("sample_count")
+                                     or len(act.data.get("samples", []) or []))
+                                self._append_md(
+                                    f"Filled the Metadata Builder for {n} "
+                                    f"sample{'s' if n != 1 else ''}. Review the values "
+                                    "and tell me anything you'd like to change."
+                                )
+                                # Bulk fill completes the form in one pass — do NOT add
+                                # to auto_previews, so it doesn't trigger an auto-continue.
+                            # Only count as a meaningful change if it wasn't a structural
+                            # trigger or a same-value no-op re-call from the model.
+                            elif not _silent_auto:
+                                auto_previews.append(act.preview)
+                            if not batch:
+                                self.refresh_context_bar()
+                else:
+                    self._add_action_card(act)
+        finally:
+            if batch:
+                set_pulse_suppressed(False)
+                self.refresh_context_bar()
 
         if auto_previews:
             self._append_md("Filled in: " + " · ".join(auto_previews))
@@ -543,7 +602,7 @@ class AssistantDock(QWidget):
         # instead of rendering a scary "Already set" card.
         if (
             noop_previews and not auto_previews and self.action_tray_layout.count() == 0
-            and not (self._streaming_text or "").strip()
+            and not self._text_asks_question(self._streaming_text)
         ):
             self._pending_auto_continue = noop_previews
         # Defer auto-continue until _on_finished so ChatWorker1's _finalize_streaming()
@@ -554,9 +613,26 @@ class AssistantDock(QWidget):
         # streaming response, otherwise the loop never terminates.
         if (
             had_auto and auto_previews and self.action_tray_layout.count() == 0
-            and not (self._streaming_text or "").strip()
+            and not self._text_asks_question(self._streaming_text)
         ):
             self._pending_auto_continue = auto_previews
+
+    @staticmethod
+    def _text_asks_question(text: str | None) -> bool:
+        """True if the streamed assistant text already poses a follow-up question.
+
+        The model usually streams a one-line acknowledgement ("Got it — 22 samples.")
+        alongside its tool call; that must NOT suppress auto-continue, otherwise the
+        guided flow stalls. Only an actual question (a '?' at/near the end) means the
+        bot has already prompted the user, so we should not auto-continue."""
+        t = (text or "").strip()
+        if not t:
+            return False
+        tail = t.rstrip(" *_`)\n\t")
+        if tail.endswith("?"):
+            return True
+        # A '?' within the last stretch of text also counts (e.g. trailing emoji/note).
+        return "?" in t[-120:]
 
     def _is_noop_action(self, action: ProposedAction) -> bool:
         return bool(action.data.get("no_op"))
@@ -583,6 +659,19 @@ class AssistantDock(QWidget):
 
         if action.kind == "add_queue_step":
             return False  # adding to the queue is a deliberate action
+
+        if action.kind == "bulk_fill_metadata":
+            return True  # deterministic bulk fill applies in one guarded pass
+
+        if action.kind == "select_segmentation_method":
+            # Apply only when it changes the current selection.
+            seg = getattr(self.main_widget, "segmentation_tab", None)
+            combo = getattr(seg, "method_combo", None) if seg is not None else None
+            if combo is None:
+                return False
+            cur = combo.currentText()
+            val = str(action.data.get("value", "")).strip()
+            return not (cur == val or cur.startswith(val) or (val and val in cur))
 
         if action.kind == "fill_metadata_builder":
             field = action.data.get("field")
@@ -711,22 +800,28 @@ class AssistantDock(QWidget):
             self._auto_continue([action.preview] if action.preview else [])
 
     def _auto_continue(self, applied: list[str] | None = None):
-        """Silently prompt the bot to continue, naming what was just applied."""
+        """Silently prompt the bot to continue, naming what was just applied.
+
+        Continues as long as each turn makes NEW progress (a distinct applied value);
+        only stops after two consecutive stalled turns (a repeated or empty signature),
+        so legitimate multi-field guided flows run to completion instead of cutting off
+        after a fixed number of turns."""
         signature = tuple(applied or [])
-        if (
-            self._auto_continue_turns >= 1
-            and signature == self._last_auto_continue_signature
-        ):
+        made_progress = bool(signature) and signature not in self._auto_continue_seen_signatures
+        if made_progress:
+            self._auto_continue_seen_signatures.add(signature)
+            self._auto_continue_stall_count = 0
+        else:
+            self._auto_continue_stall_count += 1
+        # Stop only when we've stalled (no NEW distinct value) twice in a row.
+        if self._auto_continue_stall_count >= 2:
             self._append_md(
-                "That value is already set, so I am pausing instead of repeating "
-                "the same suggestion. Ask me what to check next, or use a guide button."
+                "I paused because I wasn't making new progress. Tell me the next value "
+                "you want to set, or use one of the buttons below."
             )
             return
-        if self._auto_continue_turns >= 2:
-            self._append_md(
-                "I paused the guided flow to avoid repeating myself. "
-                "Tell me the next value you want to set, or use one of the buttons below."
-            )
+        # Hard safety ceiling against a runaway loop in pathological cases.
+        if self._auto_continue_turns >= 40:
             return
         self._auto_continue_turns += 1
         self._last_auto_continue_signature = signature
@@ -747,6 +842,20 @@ class AssistantDock(QWidget):
         except Exception:
             pass
         step = ctx.get("current_tab_label") or ctx.get("current_step", "this step")
+        if ctx.get("current_step") == "visualization":
+            # The Visualization tab has no tunable parameters — describe only the
+            # controls that are actually on screen, not config-only fields.
+            self._send_message(
+                "Explain the Visualization tab. It has no tunable parameters — only "
+                "these on-screen controls: the Dataset section (Sample selector, "
+                "'Clear existing layers before loading', and 'Load Dataset into Napari'), "
+                "the Visibility Toggles (Raw, Segments, Tracked Segments, Tracks), and "
+                "the Manual Edition section (pick tracked segments and 'Edit tracked "
+                "segments'). Describe what each of these controls does — do not mention "
+                "any other parameters.",
+                display_text="Explain this screen",
+            )
+            return
         self._send_message(
             f"Explain the {step} tab: what does it do, and what do its key "
             "parameters mean for someone configuring it for the first time?",

--- a/behav3d/napari/_assistant_actions.py
+++ b/behav3d/napari/_assistant_actions.py
@@ -518,8 +518,21 @@ def _push_to_widget(widget, value) -> bool:
         return False
 
 
+# When True, pulse_widget() is a no-op. Set during batch/bulk applies so a flood
+# of fills doesn't schedule hundreds of QTimers + stylesheet thrash (which can
+# freeze the GUI). See AssistantDock._on_tool_calls and apply_bulk_fill_metadata.
+_SUPPRESS_PULSE = False
+
+
+def set_pulse_suppressed(flag: bool) -> None:
+    global _SUPPRESS_PULSE
+    _SUPPRESS_PULSE = bool(flag)
+
+
 def pulse_widget(widget, msec: int = 1200) -> None:
     """Briefly highlight a widget with a transient stylesheet glow."""
+    if _SUPPRESS_PULSE:
+        return
     try:
         from qtpy.QtCore import QTimer
         original = widget.styleSheet()
@@ -620,6 +633,34 @@ def build_actions(raw_tool_calls: list[dict], cards: list[dict], params: dict) -
             ) and not args.get("cell_type"):
                 act.ok = False
                 act.message = "Choose the visible cell type name for this sample field."
+            actions.append(act)
+        elif name == "bulk_fill_metadata":
+            samples = args.get("samples", []) or []
+            act = ProposedAction(
+                "bulk_fill_metadata",
+                n_samples=args.get("n_samples"),
+                n_organoids=args.get("n_organoids"),
+                n_immune=args.get("n_immune"),
+                n_other=args.get("n_other"),
+                include_dead=args.get("include_dead"),
+                organoid_names=args.get("organoid_names", []) or [],
+                immune_names=args.get("immune_names", []) or [],
+                other_names=args.get("other_names", []) or [],
+                samples=samples,
+                sample_count=len(samples),
+            )
+            act.preview = f"Fill the Metadata Builder ({len(samples)} samples)"
+            if not samples:
+                act.ok = False
+                act.message = "No per-sample data provided for bulk fill."
+            actions.append(act)
+        elif name == "select_segmentation_method":
+            value = args.get("value")
+            act = ProposedAction("select_segmentation_method", value=value)
+            act.preview = f"Segmentation method → {value}"
+            if not value:
+                act.ok = False
+                act.message = "No segmentation method provided."
             actions.append(act)
     return actions
 
@@ -840,6 +881,110 @@ def apply_fill_metadata_builder(main_widget, action: ProposedAction) -> bool:
     return False
 
 
+def apply_bulk_fill_metadata(main_widget, action: ProposedAction) -> bool:
+    """Fill the ENTIRE Metadata Builder in one guarded pass.
+
+    Sets the population counts and cell-type names, then does exactly ONE
+    configure pass and ONE sample-form rebuild, then writes every provided
+    per-sample value. Pulses are suppressed so the batch doesn't schedule a
+    storm of QTimers (the cause of the GUI freeze on "fill everything")."""
+    dp = _dp(main_widget)
+    if dp is None:
+        return False
+    d = action.data
+    set_pulse_suppressed(True)
+    try:
+        if not getattr(dp.builder_grp, "isChecked", lambda: True)():
+            dp.builder_grp.setChecked(True)
+        # 1. population counts (only when provided)
+        for field, attr in (("n_samples", "n_samples_spin"),
+                            ("n_organoids", "n_organoid_spin"),
+                            ("n_immune", "n_immune_spin"),
+                            ("n_other", "n_other_spin")):
+            if d.get(field) is not None:
+                try:
+                    getattr(dp, attr).setValue(int(d[field]))
+                except Exception:
+                    pass
+        if d.get("include_dead") is not None:
+            dp.include_dead_cb.setChecked(_coerce_bool(d["include_dead"]))
+        # 2. ONE configure pass + cell-type names
+        dp._on_configure_cell_types(force=True)
+        for attr, key in (("_organoid_name_edits", "organoid_names"),
+                          ("_immune_name_edits", "immune_names"),
+                          ("_other_name_edits", "other_names")):
+            edits = getattr(dp, attr, [])
+            for i, name in enumerate(d.get(key, []) or []):
+                if i < len(edits):
+                    edits[i].setText(str(name))
+        # 3. ONE sample-form rebuild (picks up the names just set)
+        dp._build_sample_forms(force=True)
+        # 4. all per-sample values in a single pass
+        forms = getattr(dp, "_sample_forms", [])
+        cell_field_map = {
+            "line": "line", "cell_line": "line",
+            "condition": "condition", "cell_condition": "condition",
+            "segments_image_path": "segments_image_path",
+            "cell_segments_image_path": "segments_image_path",
+            "tracks_image_path": "tracks_image_path",
+            "cell_tracks_image_path": "tracks_image_path",
+            "tracks_csv_path": "tracks_csv_path",
+            "cell_tracks_csv_path": "tracks_csv_path",
+        }
+        for idx, sample in enumerate(d.get("samples", []) or []):
+            if idx >= len(forms) or not isinstance(sample, dict):
+                break
+            form = forms[idx]
+            for k, v in sample.items():
+                if k == "cell_types":
+                    continue
+                if k in ("dead_channel_number", "dead_mask_path"):
+                    dk = "number" if k == "dead_channel_number" else "mask_path"
+                    w = form.get("dead_channel", {}).get(dk)
+                else:
+                    w = form.get("basic", {}).get(k)
+                if w is not None:
+                    _push_to_widget(w, v)
+            for ct_name, ct_vals in (sample.get("cell_types") or {}).items():
+                ct_fields = (form.get("cell_types") or {}).get(str(ct_name), {})
+                if not isinstance(ct_vals, dict):
+                    continue
+                for fk, fv in ct_vals.items():
+                    target = ct_fields.get(cell_field_map.get(fk, fk))
+                    if target is not None:
+                        _push_to_widget(target, fv)
+        return True
+    except Exception:
+        return False
+    finally:
+        set_pulse_suppressed(False)
+
+
+def apply_select_segmentation_method(main_widget, value) -> bool:
+    """Select the global Segmentation Method dropdown by its visible label.
+
+    Matches exact → starts-with → contains so a leading label token ('APOC',
+    'Pixel Classifier', 'Cellpose', …) resolves to the labelled combo item.
+    Starts-with ordering keeps 'Pixel Classifier' from matching
+    'ConvPaint (DL pixel classifier)'. Setting the index swaps the param page."""
+    seg = getattr(main_widget, "segmentation_tab", None)
+    combo = getattr(seg, "method_combo", None) if seg is not None else None
+    if combo is None or value is None:
+        return False
+    try:
+        from qtpy.QtCore import Qt
+        s = str(value).strip()
+        for flag in (Qt.MatchFixedString, Qt.MatchStartsWith, Qt.MatchContains):
+            i = combo.findText(s, flag)
+            if i >= 0:
+                combo.setCurrentIndex(i)
+                pulse_widget(combo)
+                return True
+    except Exception:
+        pass
+    return False
+
+
 def apply_action(main_widget, action: ProposedAction) -> bool:
     if not action.ok:
         return False
@@ -854,6 +999,14 @@ def apply_action(main_widget, action: ProposedAction) -> bool:
         return _apply_add_queue_step(main_widget, action)
     if action.kind == "fill_metadata_builder":
         ok = apply_fill_metadata_builder(main_widget, action)
+        action.data["widget_updated"] = ok
+        return ok
+    if action.kind == "bulk_fill_metadata":
+        ok = apply_bulk_fill_metadata(main_widget, action)
+        action.data["widget_updated"] = ok
+        return ok
+    if action.kind == "select_segmentation_method":
+        ok = apply_select_segmentation_method(main_widget, action.data.get("value"))
         action.data["widget_updated"] = ok
         return ok
     return False
@@ -982,6 +1135,58 @@ TOOL_SCHEMA = [
                 },
             },
             "required": ["field"],
+        },
+    },
+    {
+        "name": "bulk_fill_metadata",
+        "description": (
+            "Fill the ENTIRE Metadata Builder in ONE call. Use this (instead of "
+            "many fill_metadata_builder calls) when the user gives lots of values "
+            "at once, provides a list of image files, or says 'fill everything'. "
+            "The app rebuilds the forms once and applies all values in a single "
+            "pass with no per-field confirmation. Provide the population counts, "
+            "cell-type name lists, and one dict per sample."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "n_samples": {"type": "integer"},
+                "n_organoids": {"type": "integer"},
+                "n_immune": {"type": "integer"},
+                "n_other": {"type": "integer"},
+                "include_dead": {"type": "boolean"},
+                "organoid_names": {"type": "array", "items": {"type": "string"}},
+                "immune_names": {"type": "array", "items": {"type": "string"}},
+                "other_names": {"type": "array", "items": {"type": "string"}},
+                "samples": {
+                    "type": "array",
+                    "description": (
+                        "One object per sample, in order. Recognised keys: "
+                        "sample_name, exp_nr, well, raw_image_path, dimension_order, "
+                        "pixel_distance_xy, pixel_distance_z, time_interval, time_unit, "
+                        "dead_channel_number, dead_mask_path, and an optional "
+                        "'cell_types' object mapping each visible cell-type name to "
+                        "{line, condition, segments_image_path, tracks_image_path, "
+                        "tracks_csv_path}."
+                    ),
+                    "items": {"type": "object"},
+                },
+            },
+            "required": ["samples"],
+        },
+    },
+    {
+        "name": "select_segmentation_method",
+        "description": (
+            "Select the global Segmentation Method dropdown on the Segmentation tab "
+            "(this swaps the visible parameter page). Use the leading visible label: "
+            "'APOC', 'ConvPaint', 'Pixel Classifier', 'Cellpose', or "
+            "'Import segmentation'."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+            "required": ["value"],
         },
     },
 ]

--- a/behav3d/napari/_assistant_client.py
+++ b/behav3d/napari/_assistant_client.py
@@ -52,7 +52,7 @@ def load_client_config() -> dict:
     endpoint = os.environ.get("BEHAV3D_ASSISTANT_ENDPOINT", cfg.get("endpoint", ""))
     token = os.environ.get("BEHAV3D_ASSISTANT_TOKEN", cfg.get("token", ""))
     return {"endpoint": endpoint.rstrip("/"), "token": token,
-            "timeout": cfg.get("timeout", 60)}
+            "timeout": cfg.get("timeout", 45)}
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +130,13 @@ class ChatWorker(QObject):
         import requests  # available in the behav3d env
         headers = {"Content-Type": "application/json"}
         payload = {"messages": self._messages, "context": self._context, "tools": self._tools}
+        # Split timeout: cap connect at 10s, read at the configured value, so a
+        # stalled server doesn't leave the dock "thinking" (and buttons greyed) for
+        # the whole window. A warm Modal container (min_containers=1) makes 10s ample.
+        timeout = cfg.get("timeout", 45)
+        ct = timeout if isinstance(timeout, (tuple, list)) else (10, timeout)
         with requests.post(f"{cfg['endpoint']}/chat", json=payload, headers=headers,
-                           stream=True, timeout=cfg.get("timeout", 60)) as resp:
+                           stream=True, timeout=ct) as resp:
             resp.raise_for_status()
             for raw in resp.iter_lines(decode_unicode=True):
                 if not raw:

--- a/behav3d/napari/_assistant_context.py
+++ b/behav3d/napari/_assistant_context.py
@@ -368,7 +368,12 @@ def build_context(main_widget) -> dict:
         "metadata": summarize_metadata(metadata),
         "queue": queue,
         "parameters": _safe(lambda: _diff_from_defaults(params), {}) or {},
-        "step_schema": _safe(lambda: cards_for_step(step), []) or [],
+        # The Visualization tab is a viewer with no tunable BEHAV3D parameters that
+        # have visible widgets (its schema cards — use_range/start_t/end_t/
+        # channel_colors — are phantom controls). Don't feed them to the model, or
+        # "Explain this screen" describes parameters the user can't see.
+        "step_schema": [] if step == "visualization"
+                       else (_safe(lambda: cards_for_step(step), []) or []),
     }
     # Include metadata builder state only when on the data_preparation tab.
     if step == "data_preparation":

--- a/behav3d/napari/_data_preparation.py
+++ b/behav3d/napari/_data_preparation.py
@@ -288,7 +288,7 @@ class DataPreparationTab(QWidget):
         lay.addLayout(self.cell_type_naming_container)
 
         btn_configure = QPushButton("Configure Cell Types")
-        btn_configure.clicked.connect(self._on_configure_cell_types)
+        btn_configure.clicked.connect(lambda: self._on_configure_cell_types(force=True))
         lay.addWidget(btn_configure)
 
         # --- Sample form area (dynamically rebuilt) ---
@@ -317,7 +317,18 @@ class DataPreparationTab(QWidget):
         self._sample_forms: list[dict] = []
 
     # --- configure cell-type naming fields --------------------------------
-    def _on_configure_cell_types(self):
+    def _on_configure_cell_types(self, force: bool = False):
+        # Idempotent: when the existing naming fields already match the configured
+        # counts, skip the destructive rebuild so entered names survive. The
+        # assistant may re-trigger this structurally; user button clicks pass
+        # force=True to always rebuild.
+        if (not force
+                and (self._organoid_name_edits or self._immune_name_edits
+                     or self._other_name_edits)
+                and len(self._organoid_name_edits) == self.n_organoid_spin.value()
+                and len(self._immune_name_edits) == self.n_immune_spin.value()
+                and len(self._other_name_edits) == self.n_other_spin.value()):
+            return
         # Clear old
         self._clear_layout(self.cell_type_naming_container)
 
@@ -380,10 +391,34 @@ class DataPreparationTab(QWidget):
 
         # After naming is set, build sample forms
         btn = QPushButton("Create Sample Forms")
-        btn.clicked.connect(self._build_sample_forms)
+        btn.clicked.connect(lambda: self._build_sample_forms(force=True))
         self.cell_type_naming_container.addWidget(btn)
 
-    def _build_sample_forms(self):
+    def _sample_forms_match_current(self) -> bool:
+        """True if the existing sample forms already match the configured sample
+        count, cell-type names and dead-channel flag — so a rebuild would only
+        destroy values the user (or assistant) already entered."""
+        forms = getattr(self, "_sample_forms", [])
+        if not forms or len(forms) != self.n_samples_spin.value():
+            return False
+        org = [e.text().strip() for e in self._organoid_name_edits]
+        imm = self._expanded_immune_names()
+        oth = [e.text().strip() for e in self._other_name_edits]
+        include_dead = self.include_dead_cb.isChecked()
+        for form in forms:
+            if (form.get("org_names") != org or form.get("imm_names") != imm
+                    or form.get("oth_names") != oth):
+                return False
+            if include_dead != bool(form.get("dead_channel")):
+                return False
+        return True
+
+    def _build_sample_forms(self, force: bool = False):
+        # Idempotent: skip the destructive rebuild when the forms already match the
+        # configured structure, so entered values survive structural re-triggers
+        # from the assistant. User button clicks pass force=True to always rebuild.
+        if not force and self._sample_forms_match_current():
+            return
         self._clear_layout(self.sample_form_container)
         self._sample_forms = []
 
@@ -672,8 +707,8 @@ class DataPreparationTab(QWidget):
         self.n_other_spin.setValue(len(oth_types))
         self.include_dead_cb.setChecked(include_dead)
 
-        # Build cell type naming fields
-        self._on_configure_cell_types()
+        # Build cell type naming fields (force: loading replaces any prior structure)
+        self._on_configure_cell_types(force=True)
 
         # Fill naming edits with detected names
         for i, name in enumerate(org_types):
@@ -691,8 +726,8 @@ class DataPreparationTab(QWidget):
             if i < len(self._other_name_edits):
                 self._other_name_edits[i].setText(name)
 
-        # Build sample forms
-        self._build_sample_forms()
+        # Build sample forms (force: loading replaces any prior structure)
+        self._build_sample_forms(force=True)
 
     @staticmethod
     def _collapse_multicolor_immune_names(imm_types):

--- a/behav3d/napari/_widget.py
+++ b/behav3d/napari/_widget.py
@@ -2,7 +2,7 @@
 BEHAV3D napari plugin – main dock widget.
 Provides a QTabWidget with tabs for the full BEHAV3D pipeline.
 """
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QTabWidget
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QTabWidget, QPushButton
 from qtpy.QtCore import Qt, QSize
 import napari
 
@@ -42,6 +42,20 @@ class BEHAV3DWidget(QWidget):
         outer_layout.setContentsMargins(0, 0, 0, 0)
         outer_layout.setSpacing(0)
         layout = outer_layout
+
+        # --- Assistant show/hide toggle -----------------------------------
+        # Lets the user reclaim space, or recover the dock if it was closed by
+        # accident. Closing the dock only hides it, so the conversation survives.
+        header = QHBoxLayout()
+        header.setContentsMargins(6, 4, 6, 0)
+        header.addStretch(1)
+        self.btn_toggle_assistant = QPushButton("💬 Assistant")
+        self.btn_toggle_assistant.setCheckable(True)
+        self.btn_toggle_assistant.setChecked(True)
+        self.btn_toggle_assistant.setToolTip("Show or hide the BEHAV3D Assistant panel")
+        self.btn_toggle_assistant.clicked.connect(self._toggle_assistant)
+        header.addWidget(self.btn_toggle_assistant)
+        layout.addLayout(header)
 
         self.tabs = QTabWidget()
         layout.addWidget(self.tabs, stretch=1)
@@ -163,6 +177,14 @@ class BEHAV3DWidget(QWidget):
             # path) and re-split them *horizontally* → pipeline | assistant.
             from qtpy.QtCore import QTimer
             QTimer.singleShot(0, self._place_assistant_beside)
+            # Keep the toggle button in sync if the dock is shown/hidden by other
+            # means (e.g. its native close button → hide, not destroy).
+            try:
+                self._assistant_dock.visibilityChanged.connect(
+                    self._on_assistant_visibility_changed
+                )
+            except Exception:
+                pass
             # Keep the assistant's context bar in sync with workflow state.
             self.tabs.currentChanged.connect(
                 lambda *_: self.assistant.refresh_context_bar()
@@ -174,6 +196,32 @@ class BEHAV3DWidget(QWidget):
         except Exception as e:  # pragma: no cover - defensive
             import warnings
             warnings.warn(f"BEHAV3D Assistant could not be initialised: {e}")
+            # No dock to toggle — disable the button so it isn't a dead control.
+            try:
+                self.btn_toggle_assistant.setEnabled(False)
+            except Exception:
+                pass
+
+    def _toggle_assistant(self):
+        """Show or hide the assistant dock. Closing only hides the dock, so the
+        conversation is preserved and the panel can be reopened instantly."""
+        dock = self._assistant_dock
+        if dock is None:
+            return
+        try:
+            visible = dock.isVisible()
+            dock.setVisible(not visible)
+            self.btn_toggle_assistant.setChecked(not visible)
+        except Exception:
+            pass
+
+    def _on_assistant_visibility_changed(self, visible: bool):
+        """Mirror the dock's visibility onto the toggle button without re-emitting."""
+        try:
+            self.btn_toggle_assistant.blockSignals(True)
+            self.btn_toggle_assistant.setChecked(bool(visible))
+        finally:
+            self.btn_toggle_assistant.blockSignals(False)
 
     def _place_assistant_beside(self):
         """Move the assistant dock to sit side-by-side (horizontally) with this

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -39,7 +39,8 @@ import re
 # ===========================================================================
 _TOOLCALL_RE = re.compile(r"<TOOLCALL>\s*(\{.*?\})\s*</TOOLCALL>", re.DOTALL)
 
-_TOOL_NAMES = ("set_parameter", "navigate_to_step", "add_queue_step", "fill_metadata_builder")
+_TOOL_NAMES = ("set_parameter", "navigate_to_step", "add_queue_step", "fill_metadata_builder",
+               "bulk_fill_metadata", "select_segmentation_method")
 
 
 _CATEGORY_LABELS = {
@@ -130,11 +131,17 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "search radius\". Do not mention Python variables, dotted keys, JSON, or "
         "tool-call syntax unless the user explicitly asks for implementation details.\n\n"
         "TOOLS — always call a tool instead of asking the user to click manually:\n"
-        "- `fill_metadata_builder`: guide through the Metadata Builder step-by-step. "
+        "- `fill_metadata_builder`: guide through the Metadata Builder one field at a time. "
         "  Use whenever the user asks to build metadata or be walked through setup.\n"
+        "- `bulk_fill_metadata`: fill the WHOLE Metadata Builder in one call. Use when the "
+        "  user gives many values at once, provides a list of image files, or says 'fill "
+        "  everything' — do not fill field-by-field in that case.\n"
         "- `set_parameter`: propose a parameter change using a dotted key from "
-        "  PARAMETERS FOR THIS STEP. NEVER use set_parameter for the segmentation "
-        "  method selector — tell the user to click the Method dropdown instead.\n"
+        "  PARAMETERS FOR THIS STEP. Do NOT use set_parameter for the segmentation Method "
+        "  selector — use select_segmentation_method instead.\n"
+        "- `select_segmentation_method`: set the global Method dropdown on the Segmentation "
+        "  tab (value = the visible label, e.g. 'APOC', 'ConvPaint', 'Pixel Classifier', "
+        "  'Cellpose', 'Import segmentation').\n"
         "- `navigate_to_step`: switch the active tab. Use proactively when a "
         "  prerequisite is missing (e.g. metadata not loaded → navigate to data_preparation).\n"
         "- `add_queue_step`: add a processing step to the queue.\n\n"
@@ -154,6 +161,8 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
 
     step = context.get("current_step", "?")
     md = context.get("metadata", {})
+    mb_ctx = context.get("metadata_builder", {}) or {}
+    csv_loaded = md.get("loaded", False)
     assistant_session = context.get("assistant_session", {}) or {}
     confirmed_keys = set(assistant_session.get("confirmed_parameter_keys", []) or [])
     active_ct = context.get("active_cell_type_tab")
@@ -162,7 +171,9 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "## CONTEXT\n"
         f"- Current step/tab: {context.get('current_tab_label', step)}\n"
         f"- Output dir set: {context.get('output_dir_set')}\n"
-        f"- Samples loaded: {md.get('n_samples', 0) if md.get('loaded') else 0}\n"
+        f"- Metadata CSV loaded: {csv_loaded}\n"
+        f"- Samples in loaded CSV: {md.get('n_samples', 0) if csv_loaded else 0}\n"
+        f"- Samples being entered in Metadata Builder: {mb_ctx.get('n_samples', 0)}\n"
         f"- Cell types: {md.get('cell_types', {})}\n"
         f"- Non-default parameters: {context.get('parameters', {})}\n"
         f"- Queue: {[s.get('type') for s in context.get('queue', [])]}"
@@ -231,7 +242,9 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
             "cell_segments_image_path, cell_tracks_image_path, and cell_tracks_csv_path "
             "with the exact visible cell_type name. "
             "After filling Sample 1, call fill_down to copy shared values to all others. "
-            "Never skip configure_cell_types or create_sample_forms — they are required actions."
+            "Never skip configure_cell_types or create_sample_forms — they are required actions.\n"
+            "IMPORTANT: every value shown above is ALREADY FILLED IN — never ask the user "
+            "to provide it again. Only ask for fields that are still blank or at their default."
         )
 
     seg = context.get("segmentation", {}) or {}
@@ -282,34 +295,48 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
     # Per-step guided flow instructions.
     _step_guides = {
         "data_preparation": (
-            "Check whether the output directory is set first. If it is not set, ask for "
-            "the output directory path; when the user answers, call set_parameter with "
-            "internal key paths.output_dir. "
-            "If metadata is not loaded, guide through the builder in this exact sequence:\n"
-            "1. Call fill_metadata_builder(open_builder)\n"
-            "2. Ask 'How many samples?' → user answers N → call fill_metadata_builder(n_samples=N)\n"
-            "3. Ask 'How many organoid types?' → call fill_metadata_builder(n_organoids=N)\n"
-            "4. Ask 'How many immune cell types?' → call fill_metadata_builder(n_immune=N)\n"
-            "5. Ask 'How many other cell types?' → call fill_metadata_builder(n_other=N)\n"
-            "6. Call fill_metadata_builder(configure_cell_types) (no user input needed)\n"
-            "7. For each organoid type: ask its name → call fill_metadata_builder(organoid_name=X, index=i)\n"
-            "8. Repeat for immune_name and other_name\n"
-            "9. Call fill_metadata_builder(create_sample_forms) (no user input needed)\n"
-            "10. For each sample: ask image path → call fill_metadata_builder(raw_image_path=P, index=i); "
-            "ask pixel size → fill pixel_distance_xy/z; ask time interval → fill time_interval/time_unit\n"
-            "11. Ask for line/condition only when the metadata needs it; fill those with "
-            "cell_line/cell_condition and the visible cell_type name\n"
-            "12. Call fill_metadata_builder(fill_down) to copy shared values when appropriate\n"
-            "CRITICAL: steps that say 'user answers N → call ...' require a tool call in that same turn. "
-            "Never skip it."
+            "FIRST read the ## METADATA BUILDER STATE block above — it is the source of "
+            "truth for what is already filled in. NEVER re-ask for any value that already "
+            "appears there (a value that is already set counts as the user's answer — move "
+            "on).\n"
+            "Work through this decision order and address ONLY the first unsatisfied item, "
+            "then ask the next question:\n"
+            "1. If the output directory is not set, ask for the output directory path; on "
+            "answer, call set_parameter(key='paths.output_dir').\n"
+            "2. If the builder is not open, call fill_metadata_builder(open_builder).\n"
+            "3. For each of n_samples / n_organoids / n_immune / n_other still at its default "
+            "(1 / 0 / 0 / 0) and not yet given by the user: ask for it and call "
+            "fill_metadata_builder with the answer in the SAME turn. Skip any already above "
+            "its default.\n"
+            "4. Once the counts are set but 'Cell types configured' is False, call "
+            "fill_metadata_builder(configure_cell_types) (no user input needed).\n"
+            "5. For each cell-type name still blank, ask it and call "
+            "fill_metadata_builder(organoid_name / immune_name / other_name, index=i). Skip "
+            "names already present in organoids/immune/other.\n"
+            "6. Once names are set but 'Sample forms created' is False, call "
+            "fill_metadata_builder(create_sample_forms) (no user input needed).\n"
+            "7. For each sample, ask only for the per-sample fields that are still blank in "
+            "the 'Visible sample forms' snapshot (raw_image_path, pixel_distance_xy/z, "
+            "time_interval/time_unit, etc.) and fill them. Skip any already filled.\n"
+            "8. Ask for line/condition only when the metadata needs it; fill those with "
+            "cell_line/cell_condition and the visible cell_type name.\n"
+            "9. After Sample 1 is complete and there are multiple samples, call "
+            "fill_metadata_builder(fill_down) to copy shared values.\n"
+            "BULK SHORTCUT: if the user provides many values at once, gives a list of image "
+            "files, or says 'fill everything', call bulk_fill_metadata ONCE with all the "
+            "counts, names, and per-sample dicts instead of filling one field at a time.\n"
+            "CRITICAL: when the user gives you a value, emit the matching tool call in that "
+            "SAME turn — never acknowledge in text only."
         ),
         "segmentation": (
             "Verify metadata is loaded and output_dir is set before anything else. "
             "Ask about the global Method dropdown first. The visible choices are APOC (GPU), "
             "ConvPaint (DL pixel classifier), Pixel Classifier (Random Forest), Cellpose "
             "(Deep Learning), and Import segmentation. APOC is not the same thing as "
-            "Pixel Classifier (Random Forest). Do NOT call set_parameter for the Method "
-            "dropdown — tell the user the exact visible option to select. Once the user "
+            "Pixel Classifier (Random Forest). When the user picks a method, call "
+            "select_segmentation_method with the leading visible label ('APOC', 'ConvPaint', "
+            "'Pixel Classifier', 'Cellpose', or 'Import segmentation') — that switches the "
+            "visible parameter page — then guide that method's parameters. Once the user "
             "accepts the current/default value for a setting, move to the next setting; "
             "do not ask about it again. For Cellpose: ask number_of_channels, then "
             "labels_mode. For Pixel Classifier: ask examples_per_sample, workers, "

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -113,6 +113,7 @@ analysis/index
 :maxdepth: 2
 
 cellpose_training
+recommended_settings
 ```
 
 ```{toctree}

--- a/docs/source/recommended_settings.md
+++ b/docs/source/recommended_settings.md
@@ -1,0 +1,315 @@
+# Recommended Settings & Practical Tips
+
+This page collects **hands-on recommendations** for the BEHAV3D EXPLORER napari
+workflow — typical parameter values and practical techniques distilled from
+training sessions. It complements the per-step method pages (which explain *what*
+each setting does) by suggesting *where to start* and *what tends to work in
+practice*.
+
+```{note}
+These are **recommended starting points, not hard rules**. They may differ from a
+form's built-in default, and the best value always depends on your data
+(magnification, frame interval, cell type, signal quality). Preview / inspect the
+result and adjust. Treat the numbers below as a sensible first guess.
+```
+
+## Pipeline order
+
+Work through the dock tabs left to right:
+
+**Data Preparation → Visualization → Segmentation → Tracking → Feature Extraction
+(+ Active Killing) → Filtering → Analysis (Death Dynamics & Single-Cell Behaviour).**
+
+All other tabs require metadata to be loaded first, so always start on **Data
+Preparation**.
+
+## Data Preparation & metadata
+
+- **Output directory** — point it at the folder that holds your metadata CSV and
+  your images directory (your "run" directory). Avoid network/cloud-synced
+  locations for large data; processing writes a lot.
+- **Number of samples** = number of unique fields of view (ideally one image file
+  per FOV).
+- **Cell types** are split into **organoid types** and **immune types** — e.g.
+  enter `CD4` and `CD8` as two separate immune types. A **multicolor** option lets
+  you segment a cell type that is split across several fluorophores separately and
+  then merge the channels (e.g. T cells stained with multiple dyes).
+- After setting counts, click **Configure cell types**, name them, then **Create
+  sample forms**.
+
+Per-sample fields:
+
+| Field | What to enter |
+|---|---|
+| Name | Experiment / image name (e.g. `Exp1`) |
+| Well | e.g. `A4` — used to group FOVs from the same well (can be custom) |
+| Image path | Path to the image file for this sample |
+| Dim order | Typically `TCZYX` |
+| Pixel size | Read it from Zen / IMARIS / ImageJ for your acquisition |
+| Time interval | Often ~120 seconds (use your real acquisition interval) |
+| Dead channel # | **Zero-based** index (so `0` = the first channel) |
+
+- Use **Fill All from Sample 1** to copy shared values (pixel size, time interval)
+  across samples, then manually correct the per-sample fields that actually
+  differ (name, image path, etc.).
+- **Save** the metadata CSV, then click **Load Metadata** to make the latest
+  version active.
+- **Convert to Zarr** for fast access (e.g. CZI → Zarr): a worker count around 7
+  is a reasonable default; expect roughly 7–10 minutes per image.
+
+## Visualization
+
+- Select a sample to load it into napari. The **Layers** panel shows each channel
+  (e.g. T-cell, organoid, dead); toggle visibility with the eye icon and adjust
+  colormap / contrast limits per layer.
+- Toggle **3D view** with the small square button at the bottom-left of the canvas.
+- When **not** in 3D, the bottom slider is **time** and the top slider is **Z**.
+
+## Segmentation (APOC pixel classifier)
+
+Recommended method: **APOC (GPU)** with a probability-map + watershed strategy.
+
+### Generating training data
+
+- **Examples per sample** defaults to ~3 (first / middle / last time point). Add
+  more to capture cells dimming over time or specific events (e.g. touching
+  T cells). Counts are zero-indexed (so `0–17` means 18 images).
+- After **Generate training data**, work on one channel at a time: deselect the
+  layers you're not drawing on, and make sure the target channel/label layer is
+  selected (highlighted). Drawing only works in **2D** view.
+
+### Drawing ground-truth labels
+
+- Use **Label 1 = background** and **Label 2 = foreground**. Always draw
+  **background first**, then overlay foreground; focus on borders and uncertain
+  regions.
+- **Organoid technique:** draw background overlapping the background *and the edge*
+  of the organoid (defining the border), then draw foreground over the interior.
+  Layering it this way gives a very clean organoid border.
+- **Touching objects:** draw a thin background line between them, bordered by
+  foreground, so the classifier learns to split them into separate objects. For
+  organoids, focus this on **time point 1** of each image — propagation tracking
+  copies the segmentation forward, so the classifier only has to separate objects
+  correctly on the first time point.
+- **Elongated T cells:** draw the label slightly **thicker than the signal
+  (~3 px)**. Segmentation connects adjacent pixels, so a one-pixel line leaves
+  gaps; a little extra thickness yields one clean segment.
+- **Bleed-through:** where another channel bleeds into this one (e.g. organoid
+  signal in the T-cell channel at higher Z), paint those regions explicitly as
+  **background** so the model ignores them — even when they're much brighter.
+- **Dead mask:** mostly draw the bright, high-intensity dead "blobs"; including the
+  dimmer signal is optional and tends to be noisier.
+
+```{tip}
+Whenever you change anything in the training tab, **train the classifier before
+moving on** — drawn labels are not necessarily kept if you leave or reload
+training data without training first.
+```
+
+### Reading the probability map
+
+- Yellow = confident foreground; dark/blue = low confidence. Where an area should
+  be foreground but isn't, draw on it with the background brush on the probability
+  map and retrain — usually only small tweaks are needed.
+- Aim for **background clearly below ~0.3–0.4** and **foreground above ~0.7**, so
+  borderline (~0.5) pixels don't flicker over the threshold between slices.
+  (Anything with background probability above 0.5 is *not* treated as background.)
+
+### Training parameters (per cell type)
+
+- **Organoids** — input channels: organoid + dead only (leave out the T-cell
+  channel; it adds little and slows things down). Feature preset: large objects
+  (a.k.a. `large_quick`), sigmas `1, 2, 5, 15`.
+- **T cells** — pick the channels/features relevant to T cells. Feature preset:
+  small cells, sigmas `1, 2, 5`.
+
+Shared random-forest / instance settings:
+
+| Setting | Recommended | Note |
+|---|---|---|
+| Max depth | 5 | Too low can't learn; too high overfits |
+| n_trees | 100 | Number of classifiers that vote on foreground/background |
+| Foreground / mask threshold | 0.50 | |
+| Seed threshold | 0.80 | Used for splitting touching objects |
+| Opening (px) | 0 | Can smooth the outside of organoids |
+| Minimum size filter | 0 during training; ~500–1000 px for organoids once trained | |
+
+- Use **Apply Config to All Tabs** after configuring one cell type, then customize
+  channels/features for the others.
+- Train one cell type (e.g. organoids first) or **Train all classifiers**, then
+  review the segmentation and probability map and refine.
+- **Show classifier statistics** to see which features mattered; removing
+  high-sigma features that rank low speeds up processing.
+
+### Batch segmentation
+
+- Process **all time points**; set workers to what your machine can handle;
+  overwrite existing results if re-running.
+- A full time series can take on the order of ~1.5 hours per image — run long jobs
+  overnight, plugged in.
+- Trained classifiers are saved in the `pixel_classification` subfolder and can be
+  reused across experiments by copying that folder.
+
+## Tracking
+
+- **Organoids — propagation:** select the organoid layer; the method auto-sets to
+  propagation. It copies segmentation frame-to-frame, so there's nothing to tune.
+  It's the slower of the two (~5–10 min/sample).
+- **T cells — btrack:** select btrack, enable **global track optimization**, and
+  set workers around 4 on most laptops (keeps the machine usable). Typical
+  ~1–2 min/sample. Useful starting parameters:
+  - **Max search radius:** ~100 px (how far ahead to look for the next-frame
+    candidate along the predicted trajectory).
+  - **Distance threshold:** ~60 px (used to link tracklets during global
+    optimization).
+- **Run batch tracking (all cell types)** tracks organoids first, then T cells
+  (choose "skip existing" if already tracked).
+- **Verify it worked:** tracked segments keep the **same colour/ID across time**;
+  untracked segments get a new colour/ID every frame. Hover a label to confirm its
+  ID stays constant.
+
+## Feature extraction (+ active killing)
+
+- Intensity, contact, and depth are always extracted (fast). **Movement** (fast)
+  and **Morphology** (slower) are optional — select everything if you're willing to
+  wait; you can prune later.
+- **Death threshold** = the fraction of dead-mask pixels inside a cell at which it
+  counts as dead. Use **Preview** to see alive (green) vs dead (red) against a time
+  point you trust:
+  - **Organoids:** ~5 % (0.05) — sounds low, but organoids are large 3-D objects,
+    so a few dead cells are a small volume fraction.
+  - **T cells:** ~10 % (0.1). A binary is-dead flag is stored alongside the actual
+    intensity and percentage, so you can re-tune later.
+- **Run Batch Extraction** covers all cell types in one pass (~5–10 min/sample).
+  Output lands in `track_data/` as per-track, per-time-point feature tables; files
+  can reach ~1 GB on dense data.
+
+**Active killing** — run *after* feature extraction (it relies on extracted
+features). It links organoid death to contacting T cells: for a T cell touching an
+organoid, it looks ahead by the observation window to see whether that organoid's
+dead mask increases.
+
+| Setting | Recommended |
+|---|---|
+| Immune cell type | `tcell` |
+| Observation window | 5 time points (≈10 min) |
+| Measure | number of dead-mask pixels |
+| Threshold mode | absolute (not multiplier) |
+| Absolute threshold | ~30 (dead-mask pixels rising by ~20–30 within the window) |
+| Min contact duration | 1 |
+
+Result: a binary active-killing column (1/0) usable in clustering.
+
+```{note}
+Caveat: if many T cells contact one organoid at once, all of them may be labelled
+active killers even if only one actually kills.
+```
+
+## Track filtering
+
+Decide whether to drop or trim tracks before analysis, then run batch filtering.
+
+- **Filter tracks shorter than a minimum length** — removes short, fragmented,
+  noisy tracks. In practice: **T cells** ~10–30 time points; **organoids** rarely
+  need length filtering (occasionally a small minimum for start-of-run fusing).
+- **Trim to a maximum time point** — useful when a dye bleaches late (discard data
+  after, say, time point ~600).
+- **Maximum-length trimming** is legacy behaviour and generally **not recommended**
+  now: with accurate tracking, long tracks should be kept for per-time-point
+  classification, so trimming just discards data.
+- **Filter dead-at-start cells** — optionally exclude cells already dead at the
+  first time point.
+- Time-based filters can be set in time points/frames or hours.
+
+## Analysis — death dynamics
+
+- **Requires** organoid segmentation, tracking and feature extraction only — no
+  T-cell steps needed.
+- Select the organoid type(s) (you can combine multiple) and run. It reuses the
+  death threshold from feature extraction.
+- **Outputs per sample:** % dead organoids over time, % alive, % disappeared, and
+  the normalized dead-dye increase (scaled to 0 at the start so an already-dead
+  baseline doesn't skew it). Raw CSVs are saved next to the PDFs for re-plotting.
+- **Reading the "disappeared" (grey) bar:** a few organoids disappearing (fusing)
+  is normal; a large grey bar suggests something went wrong.
+- **Why both % and absolute dead-pixel counts:** the binary % over-represents death
+  in small organoids (their threshold is reached sooner), while absolute counts
+  lean toward big organoids. Using both — plus a size filter so organoids are
+  comparable — gives the cleanest picture.
+
+## Analysis — single-cell behavioural classification
+
+The key idea: behaviour can be classified **per time point**, not just one
+super-behaviour per whole track. There are two tabs — state classification and
+track classification.
+
+**State classification (per time point)**
+
+- **Feature selection:** cluster on dynamic/morphology features (e.g. elongation,
+  extent, solidity, speed, net displacement). Keep **binary** features (dead /
+  organoid-contacting / active-killing) *separate* — clustering on them creates
+  artificial clusters.
+- **Smoothing:** averaged over ~5 time points by default to ride out segmentation
+  errors.
+- Run it to cluster cells into primary dynamic states, then **rename** clusters by
+  meaning (e.g. high speed → scanner; round + static → static; elongated → plastic;
+  reusing a name merges clusters). Combine these with the binary groups to get a
+  full per-time-point behaviour, then collapse the long list of combinations into
+  the behaviour types you care about.
+- **Outputs:** state composition over time, per-track behaviour bars, and
+  transition matrices (the diagonal dominates because behaviour persists; removing
+  self-transitions reveals true cross-class flow).
+
+**Track classification (super-behaviours)**
+
+- Uses dynamic time warping on the sequence of per-time-point states to cluster
+  whole tracks into super-behaviours. It clusters on state *ordering*, not raw
+  speed.
+- A legacy "original BEHAVE" mode (under Advanced Configuration) runs the classic
+  DTW clustering on raw features without state classification.
+- State and track classifications can be saved as a **`.pkl` pipeline** and
+  re-applied to new, similar data for reproducible auto-clustering and renaming.
+
+## Combining multiple experiments
+
+To analyse several runs together: copy the per-sample image folders from each
+output folder into one directory and merge their metadata CSVs, then load the
+merged folder. You can segment/track each experiment with its own channels/settings
+first, then merge and run feature extraction and analysis jointly.
+
+## Performance & CPU workers
+
+- Check your core count (e.g. via system information).
+- Use roughly **half to three-quarters** of available cores so the machine stays
+  usable while it processes.
+- Keep the laptop plugged in and **disable sleep** for long runs — if the machine
+  sleeps, processing pauses (locking the screen is fine).
+
+## Settings quick reference
+
+| Step | Setting | Recommended value |
+|---|---|---|
+| Segmentation | Draw elongated T cells | ~3 px thick |
+| Segmentation | Background probability | clearly < 0.3–0.4 (>0.5 = NOT background) |
+| Segmentation | Foreground probability | > 0.7 |
+| Segmentation | Example images / sample | ~3 |
+| Segmentation | Max depth / n_trees | 5 / 100 |
+| Segmentation | Foreground / seed threshold | 0.50 / 0.80 |
+| Segmentation | Min size (trained) | ~500–1000 px (organoids) |
+| Tracking | Organoid method | propagation (~5–10 min/sample) |
+| Tracking | T-cell method | btrack (~1–2 min/sample) |
+| Tracking | Global track optimization | Enabled |
+| Tracking | Workers | ~4 |
+| Tracking | Max search radius / distance threshold | ~100 px / ~60 px |
+| Feature extraction | Organoid death threshold | ~5 % (0.05) |
+| Feature extraction | T-cell death threshold | ~10 % (0.1) |
+| Active killing | Immune cell type | `tcell` |
+| Active killing | Observation window | 5 time points (≈10 min) |
+| Active killing | Threshold mode / value | absolute / ~30 |
+| Active killing | Min contact duration | 1 |
+| Filtering | T-cell min track length | ~10–30 time points |
+| Filtering | Organoid filtering | rarely needed |
+| Single-cell | Smoothing window | ~5 time points |
+| Data prep | Dim order | `TCZYX` |
+| Data prep | Time interval | ~120 s (use your real value) |
+| Data prep | Zarr conversion workers | ~7 |

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -232,6 +232,64 @@ def test_ingest_chunkers():
     assert "Parameter: a.b" in cc[0].text and cc[0].title == "a.b"
 
 
+def test_build_actions_bulk_fill_metadata():
+    # One bulk_fill_metadata call carries the whole form; build_actions keeps the
+    # payload and a sample count, and rejects an empty samples list.
+    acts = build_actions([
+        {"name": "bulk_fill_metadata", "arguments": {
+            "n_samples": 2, "n_immune": 1, "immune_names": ["tcell"],
+            "samples": [
+                {"sample_name": "s1", "raw_image_path": "/a.tif",
+                 "cell_types": {"tcell": {"line": "Jurkat"}}},
+                {"sample_name": "s2", "raw_image_path": "/b.tif"},
+            ]}},
+        {"name": "bulk_fill_metadata", "arguments": {"samples": []}},
+    ], [], {})
+    assert acts[0].kind == "bulk_fill_metadata" and acts[0].ok
+    assert acts[0].data["sample_count"] == 2
+    assert acts[0].data["immune_names"] == ["tcell"]
+    assert "2 samples" in acts[0].preview
+    assert not acts[1].ok                       # empty samples → rejected
+
+
+def test_build_actions_select_segmentation_method():
+    acts = build_actions([
+        {"name": "select_segmentation_method", "arguments": {"value": "Cellpose"}},
+        {"name": "select_segmentation_method", "arguments": {"value": ""}},
+    ], [], {})
+    assert acts[0].kind == "select_segmentation_method" and acts[0].ok
+    assert acts[0].data["value"] == "Cellpose" and "Cellpose" in acts[0].preview
+    assert not acts[1].ok                        # empty value → rejected
+
+
+def test_new_tools_registered():
+    import app
+    from behav3d.napari._assistant_actions import TOOL_SCHEMA
+    names = {t["name"] for t in TOOL_SCHEMA}
+    assert {"bulk_fill_metadata", "select_segmentation_method"} <= names
+    # the backend text-fallback parser must also recognise the new tool names
+    assert "bulk_fill_metadata" in app._TOOL_NAMES
+    assert "select_segmentation_method" in app._TOOL_NAMES
+
+
+def test_prompt_data_prep_reconciles_state_and_lists_tools():
+    import app
+    sp = app.build_system_prompt(
+        {"current_step": "data_preparation", "step_schema": [], "parameters": {},
+         "metadata": {"loaded": False},
+         "metadata_builder": {"n_samples": 22, "n_immune": 1, "open": True,
+                              "immune_names": ["tcell"]},
+         "queue": []},
+        [], [])
+    # CONTEXT no longer claims "0 samples" while the builder holds values.
+    assert "Samples being entered in Metadata Builder: 22" in sp
+    assert "Metadata CSV loaded: False" in sp
+    # New tools are advertised, and the guide tells the model not to re-ask.
+    assert "bulk_fill_metadata" in sp
+    assert "select_segmentation_method" in sp
+    assert "NEVER re-ask" in sp or "never re-ask" in sp.lower()
+
+
 # --------------------------------------------------------------------------
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
## Summary

Fixes a cluster of reliability, responsiveness, and coverage issues in the BEHAV3D napari co-pilot chatbot, based on user testing feedback. The assistant's multi-step guided flows are driven by the frontend's auto-continue loop re-calling a single-turn backend; most of the reported failures lived in that loop, the widget-apply path, and the streaming render path.

**Targets `feature/napari_chatbot`.** Note: the backend prompt/tool changes in `chatbot/app.py` only take effect after a Modal redeploy (`python -m modal deploy chatbot/app.py`).

## What's fixed

**Data Preparation**
- **Stops after you answer** → continue the guided flow unless the streamed assistant text actually asked a follow-up question (replaces the gate that suppressed continuation whenever *any* text was streamed).
- **Re-asks already-filled data** → reconcile contradictory context (the backend reported `Samples loaded: 0` from the CSV while the builder held 22) and rewrite the data-prep guide to read builder state and skip filled fields.
- **Premature "I paused the guided flow…"** → replace the hard 2-turn cap with a progress-based stall counter (keeps going while each turn applies a new value).
- **Total freeze on "fill everything"** → make `_build_sample_forms` / `_on_configure_cell_types` idempotent (they were destroying+rebuilding all sample widgets every call; `force=True` on user clicks) and suppress the per-widget pulse `QTimer` storm during batch applies.
- **Per-path confirm spam** → new deterministic `bulk_fill_metadata` tool: one LLM turn fills the whole builder in a single guarded pass (one rebuild, no per-item confirmations).
- **Stuck "thinking" / dead buttons** → split request timeout `(10s connect, 45s read)`, clear busy-state on error, and keep the input box editable mid-turn.

**Streaming responsiveness**
- **Long answers freeze all of napari during generation** → throttle streamed-token re-renders (~90 ms coalescing timer) and skip the full-document style walk until the turn finishes, instead of re-parsing the entire transcript on every token.

**Visualization**
- **"Explain this screen" describes controls that don't exist** (range, channel colors) → drop the visualization step schema and scope the explain prompt to the real on-screen controls.

**Segmentation**
- **Agent couldn't set the Method dropdown** → new `select_segmentation_method` tool + applier; the prompt now uses it instead of forbidding it.

**Reopen / save space**
- Added a `💬 Assistant` show/hide toggle in the main panel; closing the dock now only hides it (conversation preserved) and it can be reopened instantly.

## Files
`behav3d/napari/_assistant.py`, `_assistant_actions.py`, `_assistant_client.py`, `_assistant_context.py`, `_data_preparation.py`, `_widget.py`, `chatbot/app.py`, `test/test_assistant.py`

## Verification
- All edited files compile; Qt modules import cleanly (offscreen).
- Unit suite: **20/20 passing** (16 existing + 4 new for the bulk-fill / segmentation-method tools, schema registration, and prompt reconciliation).
- **Still needs interactive napari runtime validation** (flagged for review): end-to-end guided metadata conversation, double-click idempotency, ~20-sample bulk fill, segmentation-method swap, viz-explain wording, dock reopen, and the streaming-throttle smoothness on a long answer. Several fixes are prompt/heuristic changes whose real behavior depends on the `deepseek-v4-flash` model, so the runtime pass is the real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
