### PR TITLE
Improve chatbot guidance and workflow automation

### DIFF
--- a/behav3d/analysis/track_counts.py
+++ b/behav3d/analysis/track_counts.py
@@ -1,0 +1,189 @@
+"""Track-count summaries for evaluating minimum-length filters."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+DEFAULT_MINIMUM_LENGTHS = (20, 50, 100, 200)
+MAXIMUM_LENGTH_QUERIES = 20
+
+
+def _track_id_column(frame: pd.DataFrame) -> str:
+    for name in ("TrackID", "track_id"):
+        if name in frame.columns:
+            return name
+    raise ValueError("Track feature CSV must contain TrackID or track_id.")
+
+
+def _normalize_thresholds(values: Iterable[int] | None) -> list[int]:
+    source = DEFAULT_MINIMUM_LENGTHS if values is None else values
+    thresholds = []
+    for value in source:
+        number = int(value)
+        if number < 1:
+            raise ValueError("Minimum track lengths must be positive integers.")
+        if number not in thresholds:
+            thresholds.append(number)
+    if not thresholds:
+        raise ValueError("Provide at least one minimum track length.")
+    if len(thresholds) > MAXIMUM_LENGTH_QUERIES:
+        raise ValueError(
+            f"Compare at most {MAXIMUM_LENGTH_QUERIES} minimum track lengths at once."
+        )
+    return sorted(thresholds)
+
+
+def calculate_track_count_table(
+    frame: pd.DataFrame,
+    *,
+    minimum_lengths: Iterable[int] | None = None,
+    position_t: int = 0,
+) -> tuple[pd.DataFrame, dict]:
+    """Count tracks present at one timepoint before/after length filters.
+
+    Track length is the number of unique ``position_t`` values for each
+    ``(sample_name, TrackID)`` pair. A filtered count includes only tracks whose
+    full length meets the threshold and that have a row at the requested timepoint.
+    """
+    thresholds = _normalize_thresholds(minimum_lengths)
+    query_t = int(position_t)
+    if query_t < 0:
+        raise ValueError("Timepoint must be zero or greater.")
+    required = {"sample_name", "position_t"}
+    missing = required.difference(frame.columns)
+    if missing:
+        raise ValueError(f"Track feature CSV is missing: {', '.join(sorted(missing))}.")
+    track_col = _track_id_column(frame)
+
+    clean = frame[["sample_name", track_col, "position_t"]].copy()
+    clean["position_t"] = pd.to_numeric(clean["position_t"], errors="coerce")
+    clean = clean.dropna(subset=["sample_name", track_col, "position_t"])
+    clean = clean.drop_duplicates(["sample_name", track_col, "position_t"])
+    if clean.empty:
+        raise ValueError("Track feature CSV has no valid sample, track, and timepoint rows.")
+
+    samples = [str(value) for value in clean["sample_name"].drop_duplicates()]
+    clean["sample_name"] = clean["sample_name"].astype(str)
+    lengths = (
+        clean.groupby(["sample_name", track_col], sort=False)["position_t"]
+        .nunique()
+        .rename("track_length")
+        .reset_index()
+    )
+    present = clean.loc[clean["position_t"] == query_t, ["sample_name", track_col]]
+    present = present.drop_duplicates()
+
+    base_label = f"Cell count at timepoint {query_t} (not filtered)"
+    rows = []
+    for sample in samples:
+        sample_present = present.loc[present["sample_name"] == sample, [track_col]]
+        row = {"sample_name": sample, base_label: int(sample_present[track_col].nunique())}
+        sample_lengths = lengths.loc[lengths["sample_name"] == sample]
+        for threshold in thresholds:
+            eligible = sample_lengths.loc[
+                sample_lengths["track_length"] >= threshold, track_col
+            ]
+            row[f">={threshold} timepoints"] = int(
+                sample_present.loc[sample_present[track_col].isin(eligible), track_col].nunique()
+            )
+        rows.append(row)
+
+    table = pd.DataFrame(rows)
+    numeric_columns = [column for column in table.columns if column != "sample_name"]
+    mean_row = {"sample_name": "Mean"}
+    mean_row.update({column: float(table[column].mean()) for column in numeric_columns})
+    table = pd.concat([table, pd.DataFrame([mean_row])], ignore_index=True)
+
+    observed = sorted(clean["position_t"].unique().tolist())
+    details = {
+        "position_t": query_t,
+        "minimum_lengths": thresholds,
+        "observed_min_t": observed[0],
+        "observed_max_t": observed[-1],
+        "position_present": query_t in set(observed),
+        "track_id_column": track_col,
+    }
+    return table, details
+
+
+def track_features_path(output_dir: str | Path, cell_type: str) -> Path:
+    return (
+        Path(output_dir) / "analysis" / str(cell_type) / "track_features"
+        / f"BEHAV3D_{cell_type}_combined_track_features.csv"
+    )
+
+
+def generate_track_count_summary(
+    output_dir: str | Path,
+    cell_type: str,
+    *,
+    minimum_lengths: Iterable[int] | None = None,
+    position_t: int = 0,
+) -> dict:
+    source = track_features_path(output_dir, cell_type)
+    if not source.exists():
+        raise FileNotFoundError(f"Unfiltered track features not found: {source}")
+    frame = pd.read_csv(source, low_memory=False)
+    table, details = calculate_track_count_table(
+        frame, minimum_lengths=minimum_lengths, position_t=position_t
+    )
+    qc_dir = Path(output_dir) / "analysis" / str(cell_type) / "quality_control"
+    if details["position_t"] == 0 and details["minimum_lengths"] == list(
+        DEFAULT_MINIMUM_LENGTHS
+    ):
+        filename = f"BEHAV3D_{cell_type}_track_count_summary.csv"
+    else:
+        threshold_slug = "-".join(str(value) for value in details["minimum_lengths"])
+        filename = (
+            f"BEHAV3D_{cell_type}_track_count_query_t{details['position_t']}_"
+            f"min_{threshold_slug}.csv"
+        )
+    destination = qc_dir / filename
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    table.to_csv(destination, index=False)
+    return {
+        "table": table,
+        "source_path": source,
+        "output_path": destination,
+        **details,
+    }
+
+
+def _format_number(value) -> str:
+    number = float(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def format_track_count_summary(result: dict, cell_type: str) -> str:
+    table = result["table"]
+    columns = list(table.columns)
+    headers = ["Sample", "Unfiltered"]
+    headers.extend(
+        column.replace(" timepoints", "").replace(">=", "≥")
+        for column in columns[2:]
+    )
+    lines = [
+        f"**Track counts for {cell_type} at timepoint {result['position_t']}**",
+        "",
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" if i == 0 else "---:" for i in range(len(headers))) + "|",
+    ]
+    for _, row in table.iterrows():
+        values = [str(row[columns[0]])]
+        values.extend(_format_number(row[column]) for column in columns[1:])
+        lines.append("| " + " | ".join(values) + " |")
+    lines.extend([
+        "",
+        f"Saved under **Filtering results** as `{result['output_path'].name}`.",
+    ])
+    if not result["position_present"]:
+        lines.append(
+            f"No rows were recorded at timepoint {result['position_t']}; the observed "
+            f"range is {result['observed_min_t']:g} to {result['observed_max_t']:g}."
+        )
+    return "\n".join(lines)

--- a/behav3d/napari/_assistant.py
+++ b/behav3d/napari/_assistant.py
@@ -193,18 +193,35 @@ def _fill_value_matches_current(
 
 
 _SYSTEM_PRIMER = (
-    "You are the BEHAV3D co-pilot, embedded in the napari plugin for analysing "
-    "cell behaviour in 3D fluorescent imaging. Help the user choose methods and "
-    "parameter values for their data. Ground answers in the provided step_schema "
-    "and retrieved docs. When you recommend a concrete value, also emit a "
-    "set_parameter tool call (the user confirms before it applies).\n\n"
-    "FORMATTING — keep responses easy to read in a narrow side panel:\n"
-    "- Keep it short: lead with a one-sentence answer, then detail only if useful.\n"
-    "- Use short paragraphs (1–2 sentences) separated by a blank line.\n"
-    "- Use bullet points or a numbered list for any set of items or steps.\n"
-    "- Use researcher-facing labels, not internal variable names.\n"
-    "- Avoid long dense paragraphs and walls of text."
+    "Answer as the BEHAV3D Assistant. Use researcher-facing labels, read the live "
+    "interface context before asking for values, and keep answers concise."
 )
+
+
+_RESEARCHER_LABELS = {
+    "pixel_distance_xy": "XY pixel size",
+    "pixel_distance_z": "Z pixel size",
+    "distance_unit": "distance unit",
+    "raw_image_path": "raw image path",
+    "dimension_order": "dimension order",
+    "sample_name": "sample name",
+    "time_interval": "time interval",
+    "time_unit": "time unit",
+    "position_t": "timepoint",
+    "TrackID": "track ID",
+    "track_id": "track ID",
+    "cell_type": "cell type",
+    "organoid_cells_across": "organoid size in cell widths",
+    "minimum_lengths": "minimum track lengths",
+}
+
+
+def researcher_facing_text(text: str) -> str:
+    """Replace context/schema field names that should never reach the chat UI."""
+    result = str(text or "")
+    for technical, label in _RESEARCHER_LABELS.items():
+        result = result.replace(technical, label)
+    return result
 
 
 class _ActionCard(QFrame):
@@ -237,11 +254,11 @@ class _ActionCard(QFrame):
         row = QHBoxLayout()
         row.addStretch(1)
         if action.ok:
-            btn_apply = QPushButton("Fill it in")
+            btn_apply = QPushButton("Apply change")
             btn_apply.setStyleSheet("font-size:10px;")
             btn_apply.clicked.connect(lambda: self.confirmed.emit(self.action))
             row.addWidget(btn_apply)
-        btn_dismiss = QPushButton("Dismiss")
+        btn_dismiss = QPushButton("Keep current")
         btn_dismiss.setStyleSheet("font-size:10px;")
         btn_dismiss.clicked.connect(lambda: self.dismissed.emit(self.action))
         row.addWidget(btn_dismiss)
@@ -259,24 +276,14 @@ class AssistantDock(QWidget):
         self._threads: list[tuple] = []       # keep (thread, worker) refs alive
         self._md_log: list[str] = []          # finalised transcript blocks (markdown)
         self._streaming_text = None           # in-progress assistant text, or None
-        self._greeted_tabs: set = set()       # tabs greeted this session (no repeat proactive)
         self._guided_flow_active: bool = False  # True while a step-by-step guide is running
-        self._pending_auto_continue: list | None = None  # deferred after _on_finished
-        self._auto_continue_turns: int = 0
-        self._last_auto_continue_signature: tuple | None = None
-        # Progress-based auto-continue guard: keep going as long as each turn applies a
-        # NEW distinct value; only stop after consecutive stalled turns (no new progress).
-        self._auto_continue_seen_signatures: set[tuple] = set()
-        self._auto_continue_stall_count: int = 0
-        # The metadata-builder field applied on the current turn — drives the
-        # deterministic next-question logic in _auto_continue.
-        self._last_applied_md_field: str | None = None
         # Deterministic metadata wizard state (no LLM): _md_current is the question
         # awaiting an answer; _md_queue holds the remaining questions in this phase.
         self._md_current: dict | None = None
         self._md_queue: list[dict] = []
         self._md_phase: str | None = None
-        self._confirmed_parameter_keys: set[str] = set()
+        self._current_intent: str = "free_form"
+        self._request_active = False
         # Coalesce streamed-token re-renders. Re-rendering the whole transcript on
         # every token saturates the GUI thread on long answers (the napari window
         # freezes until the stream ends). This single-shot timer batches tokens into
@@ -294,21 +301,21 @@ class AssistantDock(QWidget):
                 background-color: #232629;
                 color: #e6e6e6;
                 border: 1px solid #3a3f44;
-                border-radius: 8px;
-                padding: 12px;
-                font-family: -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+                border-radius: 4px;
+                padding: 10px;
+                font-family: "Helvetica Neue", "Segoe UI", Arial, sans-serif;
                 font-size: 13px;
                 selection-background-color: #3d6b8a;
             }
             QLineEdit {
                 background-color: #2f3338; color: #e6e6e6;
-                border: 1px solid #3a3f44; border-radius: 8px;
+                border: 1px solid #3a3f44; border-radius: 4px;
                 padding: 7px 10px; font-size: 13px;
             }
             QLineEdit:focus { border: 1px solid #5285a6; }
             QPushButton {
                 background-color: #353a3f; color: #e6e6e6;
-                border: 1px solid #454b50; border-radius: 8px;
+                border: 1px solid #454b50; border-radius: 4px;
                 padding: 7px 10px; font-size: 12px;
             }
             QPushButton:hover { background-color: #3f464c; }
@@ -323,10 +330,15 @@ class AssistantDock(QWidget):
         self.context_bar = QLabel("BEHAV3D Assistant")
         self.context_bar.setStyleSheet(
             "background:#2f3338; color:#9fc6e0; padding:7px 10px;"
-            "border:1px solid #3a3f44; border-radius:8px; font-size:11px; font-weight:600;"
+            "border:1px solid #3a3f44; border-radius:4px; font-size:11px; font-weight:600;"
         )
         self.context_bar.setWordWrap(True)
         root.addWidget(self.context_bar)
+
+        self.status_label = QLabel("")
+        self.status_label.setStyleSheet("color:#9aa4aa; font-size:11px; padding:0 2px;")
+        self.status_label.setVisible(False)
+        root.addWidget(self.status_label)
 
         # --- transcript ---------------------------------------------------
         self.transcript = QTextBrowser()
@@ -367,7 +379,6 @@ class AssistantDock(QWidget):
             self.main_widget.tabs.currentChanged.connect(self._on_tab_changed)
         except Exception:
             initial_idx = 0
-        self._greeted_tabs.add(initial_idx)
         self._set_quick_buttons(initial_idx)
 
     # ------------------------------------------------------------------
@@ -405,8 +416,8 @@ class AssistantDock(QWidget):
         # Any direct/full render supersedes a pending throttled one.
         self._render_timer.stop()
         blocks = list(self._md_log)
-        if self._streaming_text is not None:
-            blocks.append(f"**BEHAV3D Assistant**\n\n{self._streaming_text or '...'}")
+        if self._streaming_text:
+            blocks.append(f"**BEHAV3D Assistant**\n\n{self._streaming_text}")
         try:
             # A thin rule between turns gives clear visual separation.
             self.transcript.setMarkdown("\n\n---\n\n".join(blocks))
@@ -467,8 +478,13 @@ class AssistantDock(QWidget):
         if self._md_current is not None:
             self._md_handle_answer(text)
             return
-        self._guided_flow_active = False   # free-form input exits any guided flow
-        self._send_message(text)
+        # Short replies such as "APOC", "3 is fine", or "next" remain part of a
+        # button-started guide. Longer questions return to normal free-form mode.
+        guided_reply = self._guided_flow_active and len(text) <= 100
+        intent = self._current_intent if guided_reply else "free_form"
+        if not guided_reply:
+            self._guided_flow_active = False
+        self._send_message(text, intent=intent)
 
     def _send_message(
         self,
@@ -476,14 +492,13 @@ class AssistantDock(QWidget):
         *,
         show_as_user: bool = True,
         display_text: str | None = None,
-        reset_auto_loop: bool = True,
+        reset_guidance: bool = True,
+        intent: str = "free_form",
     ):
-        if reset_auto_loop:
-            self._auto_continue_turns = 0
-            self._last_auto_continue_signature = None
-            self._auto_continue_seen_signatures = set()
-            self._auto_continue_stall_count = 0
-            self._last_applied_md_field = None
+        if self._request_active:
+            return
+        self._current_intent = intent
+        if reset_guidance:
             # Any LLM-bound send (free-form or another guide button) cancels the
             # deterministic metadata wizard.
             self._md_current = None
@@ -492,6 +507,9 @@ class AssistantDock(QWidget):
         if show_as_user:
             self._append_user(display_text or text)
         self._history.append({"role": "user", "content": text})
+        # Keep only the latest 12 user/assistant exchanges. Session facts and live
+        # values are carried separately in structured context.
+        self._history = self._history[-24:]
         self._set_busy(True)
         self._streaming_text = ""        # opens a live "Assistant:" block
         self._render()
@@ -500,7 +518,7 @@ class AssistantDock(QWidget):
         try:
             ctx = build_context(self.main_widget)
             ctx["assistant_session"] = {
-                "confirmed_parameter_keys": sorted(self._confirmed_parameter_keys),
+                "intent": self._current_intent,
             }
         except Exception:
             ctx = {}
@@ -521,7 +539,10 @@ class AssistantDock(QWidget):
         thread.start()
 
     def _set_busy(self, busy: bool):
+        self._request_active = bool(busy)
         self.btn_send.setEnabled(not busy)
+        self.status_label.setText("Thinking..." if busy else "")
+        self.status_label.setVisible(bool(busy))
         # Leave the input box editable while a turn is in flight so the user can
         # type their next answer without waiting for the stream to finish.
         for i in range(self._quick_layout.count()):
@@ -540,10 +561,13 @@ class AssistantDock(QWidget):
         if self._streaming_text is None:
             self._streaming_text = ""
         self._streaming_text += chunk
+        # The model sees structured field names in live context. Enforce the
+        # researcher-facing vocabulary even if it repeats one despite prompting.
+        self._streaming_text = researcher_facing_text(self._streaming_text)
         self._schedule_render()
 
     def _on_degraded(self, full_text: str):
-        self._streaming_text = full_text
+        self._streaming_text = researcher_facing_text(full_text)
         self._render()
 
     def _on_error(self, message: str):
@@ -562,12 +586,20 @@ class AssistantDock(QWidget):
             from behav3d.napari._assistant_schema import flatten_config_to_cards
             cards = flatten_config_to_cards()
             params = getattr(self.main_widget.data_prep_tab, "behav3d_parameters", {})
-            actions = build_actions(calls, cards, params)
+            actions = build_actions(calls, cards, params,
+                                    controls=(ctx.get("ui_state", {}) or {}).get("controls", []))
         except Exception:
             actions = []
+        if actions and all(self._is_noop_action(action) for action in actions):
+            # A model may still narrate a future action despite the live value
+            # already matching. Replace that stale promise with the verified fact.
+            self._streaming_text = self._noop_response(actions)
+        if actions and self._streaming_text is not None:
+            # Tool calls arrive after streamed prose. Finalise that prose before
+            # appending action outcomes so the transcript preserves causality.
+            self._finalize_streaming()
+            self._render()
         auto_previews = []
-        noop_previews = []
-        had_auto = False
         # Suppress per-widget pulse glows when applying a batch — a flood of fills
         # would otherwise schedule hundreds of QTimers and thrash stylesheets,
         # which can freeze the GUI. One context-bar refresh happens at the end.
@@ -578,8 +610,6 @@ class AssistantDock(QWidget):
         try:
             for act in actions:
                 if self._is_noop_action(act):
-                    self._record_noop_action(act)
-                    noop_previews.append(self._noop_preview(act))
                     continue
                 if self._should_auto_apply(act):
                     if act.ok:
@@ -590,8 +620,9 @@ class AssistantDock(QWidget):
                         except Exception:
                             ok = False
                         if ok:
-                            had_auto = True
-                            if act.kind == "bulk_fill_metadata":
+                            if act.data.get("result_markdown"):
+                                self._append_action_result(act.data["result_markdown"])
+                            elif act.kind == "bulk_fill_metadata":
                                 n = (act.data.get("sample_count")
                                      or len(act.data.get("samples", []) or []))
                                 self._append_md(
@@ -599,16 +630,10 @@ class AssistantDock(QWidget):
                                     f"sample{'s' if n != 1 else ''}. Review the values "
                                     "and tell me anything you'd like to change."
                                 )
-                                # Bulk fill completes the form in one pass — do NOT add
-                                # to auto_previews, so it doesn't trigger an auto-continue.
                             # Only count as a meaningful change if it wasn't a structural
                             # trigger or a same-value no-op re-call from the model.
                             elif not _silent_auto:
                                 auto_previews.append(act.preview)
-                                # Remember the metadata field just filled so the
-                                # deterministic counts driver can ask the next one.
-                                if act.kind == "fill_metadata_builder":
-                                    self._last_applied_md_field = act.data.get("field")
                             if not batch:
                                 self.refresh_context_bar()
                 else:
@@ -623,54 +648,29 @@ class AssistantDock(QWidget):
         # A no-op means the proposed value was already present. Treat that as
         # confirmation from the user's previous answer and move forward silently
         # instead of rendering a scary "Already set" card.
-        if (
-            noop_previews and not auto_previews and self.action_tray_layout.count() == 0
-            and not self._text_asks_question(self._streaming_text)
-        ):
-            self._pending_auto_continue = noop_previews
-        # Defer auto-continue until _on_finished so ChatWorker1's _finalize_streaming()
-        # runs first — otherwise it wipes _streaming_text that ChatWorker2 just started.
-        # Only fire for value-setting actions (non-empty previews). Structural-only actions
-        # (open_builder, configure_cell_types, create_sample_forms, fill_down) must not
-        # trigger a new LLM turn — the bot should ask the next question in its current
-        # streaming response, otherwise the loop never terminates.
-        if (
-            had_auto and auto_previews and self.action_tray_layout.count() == 0
-            and not self._text_asks_question(self._streaming_text)
-        ):
-            self._pending_auto_continue = auto_previews
-
-    @staticmethod
-    def _text_asks_question(text: str | None) -> bool:
-        """True if the streamed assistant text already poses a follow-up question.
-
-        The model usually streams a one-line acknowledgement ("Got it — 22 samples.")
-        alongside its tool call; that must NOT suppress auto-continue, otherwise the
-        guided flow stalls. Only an actual question (a '?' at/near the end) means the
-        bot has already prompted the user, so we should not auto-continue."""
-        t = (text or "").strip()
-        if not t:
-            return False
-        tail = t.rstrip(" *_`)\n\t")
-        if tail.endswith("?"):
-            return True
-        # A '?' within the last stretch of text also counts (e.g. trailing emoji/note).
-        return "?" in t[-120:]
+        # Deliberately no hidden continuation request. One user or button input maps
+        # to exactly one model request, even when actions were applied or were no-ops.
 
     def _is_noop_action(self, action: ProposedAction) -> bool:
         return bool(action.data.get("no_op"))
 
-    def _record_noop_action(self, action: ProposedAction) -> None:
-        if action.kind == "set_parameter":
-            key = action.data.get("key")
-            if key:
-                self._confirmed_parameter_keys.add(str(key))
-
-    def _noop_preview(self, action: ProposedAction) -> str:
-        if action.kind == "set_parameter":
-            label = action.data.get("label") or humanize_parameter_key(action.data.get("key"))
-            return f"{label} already set to {action.data.get('value')!r}"
-        return action.preview or "Value already set"
+    def _noop_response(self, actions: list[ProposedAction]) -> str:
+        details = []
+        metadata_draft = False
+        for action in actions:
+            label = action.data.get("label") or "That field"
+            value = action.data.get("value")
+            details.append(f"{label} is already set to **{value}**")
+            metadata_draft = metadata_draft or str(
+                action.data.get("control_id") or ""
+            ).startswith("metadata.")
+        message = ". ".join(details) + ". No change was needed."
+        if metadata_draft:
+            message += (
+                " The value is in the Metadata Builder draft; save the metadata "
+                "when ready."
+            )
+        return message
 
     def _should_auto_apply(self, action: ProposedAction) -> bool:
         """Auto-apply by default; only show a confirm card if a value is already set."""
@@ -684,7 +684,7 @@ class AssistantDock(QWidget):
             return False  # adding to the queue is a deliberate action
 
         if action.kind == "bulk_fill_metadata":
-            return True  # deterministic bulk fill applies in one guarded pass
+            return False  # one confirmation covers the complete multi-field change
 
         if action.kind == "select_segmentation_method":
             # Apply only when it changes the current selection.
@@ -730,6 +730,21 @@ class AssistantDock(QWidget):
                 pass
             return True
 
+        if action.kind == "set_ui_value":
+            old = action.data.get("old_value")
+            # Empty text fields can be filled immediately. Existing values require
+            # the explicit Apply change card.
+            return old is None or (isinstance(old, str) and not old.strip())
+
+        if action.kind in (
+            "show_track_length_distribution", "open_result", "recommend_edt",
+            "summarize_track_counts",
+        ):
+            return True
+
+        if action.kind in ("create_cell_type_group", "create_btrack_config_copy"):
+            return False
+
         return True  # unknown action kind: auto-apply
 
     def _is_silent_auto_apply(self, action: ProposedAction) -> bool:
@@ -758,6 +773,7 @@ class AssistantDock(QWidget):
     def _finalize_streaming(self):
         """Move the in-progress assistant text into the finalised transcript log."""
         if self._streaming_text:
+            self._streaming_text = researcher_facing_text(self._streaming_text)
             self._md_log.append(f"**BEHAV3D Assistant**\n\n{self._streaming_text}")
             self._history.append({"role": "assistant", "content": self._streaming_text})
         self._streaming_text = None
@@ -769,11 +785,6 @@ class AssistantDock(QWidget):
         self._set_busy(False)
         if had_text:
             self._append_log()
-        # Fire any deferred auto-continue AFTER this turn is fully finalised.
-        pending = self._pending_auto_continue
-        if pending is not None:
-            self._pending_auto_continue = None
-            self._auto_continue(pending)
 
     def _cleanup_thread(self, thread, worker):
         self._threads = [(t, w) for (t, w) in self._threads if t is not thread]
@@ -793,6 +804,12 @@ class AssistantDock(QWidget):
         card.setParent(None)
         card.deleteLater()
 
+    def _append_action_result(self, markdown: str):
+        """Display a deterministic action result and retain it for follow-ups."""
+        self._append_md(markdown)
+        self._history.append({"role": "assistant", "content": markdown})
+        self._history = self._history[-24:]
+
     def _apply_action(self, action: ProposedAction):
         ok = False
         try:
@@ -800,7 +817,9 @@ class AssistantDock(QWidget):
         except Exception as e:
             self._append_md(f"\nCould not apply: {e}")
         if ok:
-            if action.kind == "set_parameter" and not action.data.get("widget_updated"):
+            if action.data.get("result_markdown"):
+                self._append_action_result(action.data["result_markdown"])
+            elif action.kind == "set_parameter" and not action.data.get("widget_updated"):
                 # stored in config, but no matching field exists on the current screen
                 label = action.data.get("label") or humanize_parameter_key(action.data.get("key"))
                 self._append_md(
@@ -818,141 +837,28 @@ class AssistantDock(QWidget):
             w = self.action_tray_layout.itemAt(i).widget()
             if isinstance(w, _ActionCard) and w.action is action:
                 self._remove_card(w)
-        if ok and action.kind == "fill_metadata_builder":
-            self._last_applied_md_field = action.data.get("field")
-        # Auto-continue: once the tray is empty, prompt the bot for the next step.
-        if ok and self.action_tray_layout.count() == 0:
-            self._auto_continue([action.preview] if action.preview else [])
 
-    def _auto_continue(self, applied: list[str] | None = None):
-        """Silently prompt the bot to continue, naming what was just applied.
-
-        Continues as long as each turn makes NEW progress (a distinct applied value);
-        only stops after two consecutive stalled turns (a repeated or empty signature),
-        so legitimate multi-field guided flows run to completion instead of cutting off
-        after a fixed number of turns."""
-        signature = tuple(applied or [])
-        made_progress = bool(signature) and signature not in self._auto_continue_seen_signatures
-        if made_progress:
-            self._auto_continue_seen_signatures.add(signature)
-            self._auto_continue_stall_count = 0
-        else:
-            self._auto_continue_stall_count += 1
-        # Stop only when we've stalled (no NEW distinct value) twice in a row.
-        if self._auto_continue_stall_count >= 2:
-            self._append_md(
-                "I paused because I wasn't making new progress. Tell me the next value "
-                "you want to set, or use one of the buttons below."
-            )
-            return
-        # Hard safety ceiling against a runaway loop in pathological cases.
-        if self._auto_continue_turns >= 40:
-            return
-        # --- Deterministic metadata guidance -------------------------------
-        # The model reliably FILLS an answer and ASKS a given question, but is
-        # unreliable at DECIDING the next field on its own (it loops on the field
-        # it just set). So during the metadata guided flow we compute the next
-        # question and tell it to ask exactly that. Verified against the live model:
-        # explicit next-question = 6/6 pass; generic "ask the next field" = 1/6.
-        md_field = self._last_applied_md_field
-        self._last_applied_md_field = None
-        if self._guided_flow_active and md_field in self._MD_COUNT_ORDER:
-            i = self._MD_COUNT_ORDER.index(md_field)
-            nxt = self._MD_COUNT_ORDER[i + 1] if i + 1 < len(self._MD_COUNT_ORDER) else None
-            if nxt is None:
-                # All four counts captured → build the cell-type fields and the
-                # per-sample forms (structural + idempotent), then hand off.
-                self._md_apply_structural("configure_cell_types")
-                self._md_apply_structural("create_sample_forms")
-                self.refresh_context_bar()
-                self._append_md(
-                    "All set — the cell-type fields and per-sample forms are ready below. "
-                    "For each sample, fill in the **image path** and acquisition settings; "
-                    "use **Fill All from Sample 1** to copy shared values (pixel size, time "
-                    "interval), rename the cell types if you like, then **Save Metadata CSV** "
-                    "and click **Load Metadata**. Ask me about any field you're unsure of."
-                )
-                self._guided_flow_active = False
-                return
-            self._auto_continue_turns += 1
-            self._last_auto_continue_signature = signature
-            label = "; ".join(applied) if applied else "That"
-            self._send_message(
-                f"{label} is set — do NOT call any tool now. Ask me exactly this next "
-                f'question: "{self._MD_COUNT_Q[nxt]}"',
-                show_as_user=False, reset_auto_loop=False,
-            )
-            return
-
-        # --- Generic fallback (set_parameter flows, etc.) ------------------
-        self._auto_continue_turns += 1
-        self._last_auto_continue_signature = signature
-        if applied:
-            msg = (
-                f"Applied: {'; '.join(applied)}. Those values are now set — do NOT set "
-                "them again. Ask me the next field that is still missing in the builder; "
-                "only call a tool after I answer."
-            )
-        else:
-            msg = ("Ask me the next field that is still missing; only call a tool after "
-                   "I answer.")
-        self._send_message(msg, show_as_user=False, reset_auto_loop=False)
-
-    # Canonical order + questions for the deterministic metadata counts phase.
-    _MD_COUNT_ORDER = ["n_samples", "n_organoids", "n_immune", "n_other"]
-    _MD_COUNT_Q = {
-        "n_organoids": "How many organoid types do you have?",
-        "n_immune": "How many immune cell types do you have?",
-        "n_other": "How many other (non-organoid, non-immune) cell types do you have?",
-    }
-
-    def _md_apply_structural(self, field: str):
+    def _md_apply_structural(self, field: str) -> bool:
         """Apply a structural metadata-builder step (configure_cell_types /
         create_sample_forms) directly, without an LLM round-trip."""
         try:
             act = ProposedAction("fill_metadata_builder", field=field, value=None, index=0)
-            apply_action(self.main_widget, act)
+            return bool(apply_action(self.main_widget, act))
         except Exception:
-            pass
+            return False
 
     # ------------------------------------------------------------------
     # Quick actions
     # ------------------------------------------------------------------
+    def _send_intent(self, intent: str, label: str):
+        """Send a short visible command plus a structured intent in context."""
+        self._send_message(label, display_text=label, intent=intent)
+
     def _explain_screen(self):
-        ctx = {}
-        try:
-            ctx = build_context(self.main_widget)
-        except Exception:
-            pass
-        step = ctx.get("current_tab_label") or ctx.get("current_step", "this step")
-        if ctx.get("current_step") == "visualization":
-            # The Visualization tab has no tunable parameters — describe only the
-            # controls that are actually on screen, not config-only fields.
-            self._send_message(
-                "Explain the Visualization tab. It has no tunable parameters — only "
-                "these on-screen controls: the Dataset section (Sample selector, "
-                "'Clear existing layers before loading', and 'Load Dataset into Napari'), "
-                "the Visibility Toggles (Raw, Segments, Tracked Segments, Tracks), and "
-                "the Manual Edition section (pick tracked segments and 'Edit tracked "
-                "segments'). Describe what each of these controls does — do not mention "
-                "any other parameters.",
-                display_text="Explain this screen",
-            )
-            return
-        self._send_message(
-            f"Explain the {step} tab: what does it do, and what do its key "
-            "parameters mean for someone configuring it for the first time?",
-            display_text="Explain this screen",
-        )
+        self._send_intent("explain_screen", "Explain this screen")
 
     def _start_interview(self):
-        self._send_message(
-            "I'd like help configuring BEHAV3D for my data. Ask me a short series "
-            "of questions about my experiment (imaging modality, cell types, frame "
-            "interval, pixel size, expected cell diameter, motility) and then "
-            "recommend sensible default parameters for the current step.",
-            display_text="Tell me about my data",
-        )
+        self._send_intent("review_data", "Review my data")
 
     def _start_metadata_guide(self):
         self._append_user("Build metadata")
@@ -978,9 +884,27 @@ class AssistantDock(QWidget):
         is applied immediately — the LLM is never in the loop, so it can't stall,
         loop, or skip a field."""
         self._guided_flow_active = True
-        self._md_apply_structural("open_builder")
+        try:
+            nav = ProposedAction("navigate_to_step", step="data_preparation")
+            apply_action(self.main_widget, nav)
+        except Exception:
+            pass
+        if not self._md_apply_structural("open_builder"):
+            self._guided_flow_active = False
+            self._append_md("Metadata Builder was not opened.")
+            return
         self._append_md("Opened the Metadata Builder")
         self.refresh_context_bar()
+        dp = getattr(self.main_widget, "data_prep_tab", None)
+        if (getattr(dp, "_edit_mode", False)
+                and bool(getattr(dp, "_sample_forms", []) or [])):
+            self._guided_flow_active = False
+            self._current_intent = "review_data"
+            self._append_md(
+                "Your loaded metadata is ready to edit. I can review the current "
+                "sample values or help change a specific field."
+            )
+            return
         self._md_phase = "counts"
         self._md_queue = [dict(s) for s in self._MD_COUNT_STEPS]
         self._md_current = None
@@ -1031,6 +955,12 @@ class AssistantDock(QWidget):
         """Apply the typed answer to the current wizard question and advance."""
         item = self._md_current
         self._append_user(text)
+        if self._md_help_requested(text):
+            self._append_md(
+                f"**BEHAV3D Assistant**\n\n{self._md_help_text(item)}\n\n"
+                f"{item['question']}"
+            )
+            return
         if item["kind"] == "count":
             try:
                 value = int("".join(ch for ch in text if (ch.isdigit() or ch == "-")))
@@ -1051,6 +981,39 @@ class AssistantDock(QWidget):
         self._md_apply_value(item["field"], value, item.get("index", 0))
         self.refresh_context_bar()
         self._md_ask_next()
+
+    @staticmethod
+    def _md_help_requested(text: str) -> bool:
+        normalized = (text or "").strip().lower()
+        return any(phrase in normalized for phrase in (
+            "help", "not sure", "what does", "what counts", "how do i know",
+        ))
+
+    @staticmethod
+    def _md_help_text(item: dict) -> str:
+        help_by_field = {
+            "n_samples": (
+                "A sample is one independently imaged field of view or acquisition "
+                "that will become one metadata row. Count image files or fields of "
+                "view, not the number of cell types inside them."
+            ),
+            "n_organoids": (
+                "Count the distinct organoid populations you want to segment and "
+                "track separately. Use 0 if your experiment has no organoids."
+            ),
+            "n_immune": (
+                "Count the distinct immune-cell populations you want BEHAV3D to "
+                "process separately, such as T cells and macrophages."
+            ),
+            "n_other": (
+                "Count any additional cell populations that are neither organoids "
+                "nor immune cells. Use 0 if there are none."
+            ),
+        }
+        return help_by_field.get(
+            item.get("field"),
+            "Use the short label you want to see for this cell population throughout BEHAV3D.",
+        )
 
     def _md_apply_value(self, field: str, value, index: int = 0):
         from behav3d.napari._assistant_actions import _metadata_builder_preview
@@ -1086,20 +1049,6 @@ class AssistantDock(QWidget):
         """Called whenever the user switches tabs in the main widget."""
         self.refresh_context_bar()
         self._set_quick_buttons(index)
-        if index not in self._greeted_tabs and not self._guided_flow_active:
-            self._greeted_tabs.add(index)
-            self._dispatch_proactive(index)
-
-    def _dispatch_proactive(self, index: int):
-        dispatch = {
-            0: self._proactive_data_prep,
-            2: self._proactive_segmentation,
-            3: self._proactive_tracking,
-            4: self._proactive_feature_extraction,
-        }
-        fn = dispatch.get(index)
-        if fn:
-            fn()
 
     def _set_quick_buttons(self, tab_index: int):
         """Clear and repopulate quick-action buttons for the given tab."""
@@ -1117,7 +1066,7 @@ class AssistantDock(QWidget):
 
         def _btn(label, handler, tip=""):
             b = QPushButton(label)
-            b.setStyleSheet("font-size:10px;")
+            b.setStyleSheet("font-size:11px; padding:5px 8px;")
             if tip:
                 b.setToolTip(tip)
             b.clicked.connect(handler)
@@ -1136,62 +1085,23 @@ class AssistantDock(QWidget):
         elif tab_index == 2:  # segmentation
             _row(_btn("Guide segmentation", self._start_segmentation_guide),
                  _btn("Choose a method", self._explain_seg_methods))
+            _row(_btn("Estimate EDT", self._estimate_edt))
         elif tab_index == 3:  # tracking
             _row(_btn("Guide tracking", self._start_tracking_guide),
                  _btn("Which method?", self._explain_tracking_methods))
         elif tab_index == 4:  # feature_extraction
             _row(_btn("Guide setup", self._start_feature_guide),
                  _btn("Check prerequisites", self._check_feature_prereqs))
+        elif tab_index == 5:  # filtering
+            _row(_btn("Review filters", self._review_filters),
+                 _btn("Track lengths", self._show_track_lengths))
+            _row(_btn("Cell counts", self._show_track_counts))
+        elif tab_index == 6:  # analysis
+            _row(_btn("Choose analysis", self._choose_analysis),
+                 _btn("Review results", self._review_results))
         else:
             _row(_btn("Explain this screen", self._explain_screen),
                  _btn("Tell me about my data", self._start_interview))
-
-    def _proactive_message(self, prompt: str):
-        """Trigger a proactive LLM check; displays as the bot's initiative, not a user message."""
-        self._append_md("*Checking your setup...*")
-        self._send_message(prompt, show_as_user=False)
-
-    # ------------------------------------------------------------------
-    # Proactive per-tab openers (fire once per tab per session)
-    # ------------------------------------------------------------------
-    def _proactive_data_prep(self):
-        self._proactive_message(
-            "I am on the Data Preparation tab. "
-            "Check the context: is output_dir_set? Is metadata loaded (metadata.loaded)? "
-            "If output_dir is not set, mention that first and offer to help. "
-            "If output_dir is set but metadata is not loaded, offer to walk through the Metadata Builder. "
-            "If both are ready, confirm briefly and suggest moving to the next step. "
-            "Keep it to 2–3 sentences maximum."
-        )
-
-    def _proactive_segmentation(self):
-        self._proactive_message(
-            "I just switched to the Segmentation tab. "
-            "Check context: is metadata loaded and output dir set? "
-            "If not, state which prereq is missing and offer to call navigate_to_step to Data Preparation. "
-            "If prerequisites are met, mention the current visible Method dropdown choice and offer "
-            "a guided walkthrough. Treat APOC, ConvPaint, Pixel Classifier, Cellpose, and Import "
-            "segmentation as distinct methods. "
-            "Keep it to 2–3 sentences."
-        )
-
-    def _proactive_tracking(self):
-        self._proactive_message(
-            "I just switched to the Tracking tab. "
-            "Check context: is metadata loaded? What cell types are listed in metadata.cell_types? "
-            "If metadata is not loaded, redirect with navigate_to_step to Data Preparation. "
-            "If loaded, state which cell types you see (immune, organoid, other) and ask if "
-            "I'd like a guided walkthrough to configure tracking methods and parameters. "
-            "Keep it to 2–3 sentences."
-        )
-
-    def _proactive_feature_extraction(self):
-        self._proactive_message(
-            "I just switched to the Feature Extraction tab. "
-            "Check context: is metadata loaded? What cell types are present? "
-            "Briefly say what this step does and mention whether key prereqs are satisfied. "
-            "Offer to guide me through setup. Keep it to 2–3 sentences."
-        )
 
     # ------------------------------------------------------------------
     # Guided-flow handlers for per-tab quick buttons
@@ -1209,81 +1119,93 @@ class AssistantDock(QWidget):
             self._append_user("Walk through setup")
             self._begin_metadata_wizard()
         else:
-            self._send_message(
-                "I need help setting up Data Preparation from scratch. "
-                "Check context — is output_dir_set? Is metadata loaded? "
-                "If output dir is not set, ask me for the path. "
-                "Otherwise open the Metadata Builder and ask me 'How many samples?' — "
-                "one question at a time.",
-                display_text="Walk through setup",
-            )
+            self._send_intent("guide_data_setup", "Walk through setup")
 
     def _check_data_prereqs(self):
-        self._send_message(
-            "Look at the current context (output_dir_set, metadata.loaded, metadata_builder state, "
-            "metadata.n_samples, metadata.cell_types) and list exactly what is missing or "
-            "incomplete on the Data Preparation tab. If everything is complete, say so and suggest "
-            "the next workflow step.",
-            display_text="Check what's missing",
-        )
+        self._send_intent("check_data_setup", "Check what's missing")
 
     def _start_segmentation_guide(self):
         self._guided_flow_active = True
-        self._send_message(
-            "I'd like a guided walkthrough of Segmentation setup. "
-            "First check that metadata is loaded and output dir is set — if not, redirect me. "
-            "Then ask which visible segmentation Method fits my data. The available choices are "
-            "APOC (GPU), ConvPaint (DL pixel classifier), Pixel Classifier (Random Forest), "
-            "Cellpose (Deep Learning), and Import segmentation. APOC is its own method, not "
-            "Pixel Classifier. One question at a time — just ask for method first.",
-            display_text="Guide segmentation",
-        )
+        self._send_intent("guide_segmentation", "Guide segmentation")
 
     def _explain_seg_methods(self):
-        self._send_message(
-            "Explain the visible segmentation methods in BEHAV3D: APOC (GPU), ConvPaint, "
-            "Pixel Classifier (Random Forest), Cellpose, and Import segmentation. "
-            "Recommend one for each of my cell types when that makes sense. "
-            "Read my cell types from the context and be concrete in your recommendation.",
-            display_text="Choose a segmentation method",
+        self._send_intent("compare_segmentation_methods", "Choose a method")
+
+    def _estimate_edt(self):
+        ctx = build_context(self.main_widget)
+        cell_type = ctx.get("active_cell_type")
+        if not cell_type:
+            groups = (ctx.get("metadata", {}).get("cell_types", {}) or {})
+            candidates = []
+            for category in ("organoid", "immune", "other"):
+                candidates.extend(groups.get(category, []) or [])
+            candidates = list(dict.fromkeys(str(value) for value in candidates))
+            if len(candidates) == 1:
+                cell_type = candidates[0]
+        if not cell_type:
+            self._send_intent("recommend_edt", "Estimate EDT")
+            return
+        self._append_user("Estimate EDT")
+        action = ProposedAction(
+            "recommend_edt", cell_type=cell_type, cell_diameter_um=10.0,
+            organoid_cells_across=None,
         )
+        action.preview = f"Calculate EDT starting values for {cell_type}"
+        if apply_action(self.main_widget, action) and action.data.get("result_markdown"):
+            self._append_action_result(action.data["result_markdown"])
+        else:
+            self._append_md(f"I could not calculate EDT values for **{cell_type}**.")
 
     def _start_tracking_guide(self):
         self._guided_flow_active = True
-        self._send_message(
-            "I'd like a guided walkthrough of Tracking setup. "
-            "Read my cell types from context and start by listing which types you see. "
-            "For each type ask which tracking method to use — state the recommended default "
-            "(btrack for immune, propagation for organoid, lap for other) and ask for confirmation. "
-            "Then ask the key parameter for that method. One question at a time.",
-            display_text="Guide tracking",
-        )
+        self._send_intent("guide_tracking", "Guide tracking")
 
     def _explain_tracking_methods(self):
-        self._send_message(
-            "Looking at my cell types in context, which tracking method do you recommend for each type "
-            "and why? Compare btrack, LAP, propagation, and trackpy. Give a concrete recommendation.",
-            display_text="Which tracking method?",
-        )
+        self._send_intent("compare_tracking_methods", "Which method?")
 
     def _start_feature_guide(self):
         self._guided_flow_active = True
-        self._send_message(
-            "I'd like a guided walkthrough of Feature Extraction setup. "
-            "Check context: are metadata loaded and output dir set? What cell types are present? "
-            "If prereqs are missing, redirect me. Otherwise ask one question at a time, "
-            "starting with: which features do I want to extract for each cell type?",
-            display_text="Guide feature extraction",
-        )
+        self._send_intent("guide_feature_extraction", "Guide setup")
 
     def _check_feature_prereqs(self):
-        self._send_message(
-            "Check whether the prerequisites for Feature Extraction are satisfied: "
-            "metadata loaded, output dir set, segmentation masks present, tracking outputs present. "
-            "Tell me specifically what is ready and what is missing. "
-            "If anything is missing, offer to navigate me to the right tab to fix it.",
-            display_text="Check prerequisites",
+        self._send_intent("check_feature_prerequisites", "Check prerequisites")
+
+    def _review_filters(self):
+        self._send_intent("review_filters", "Review filters")
+
+    def _show_track_lengths(self):
+        ctx = build_context(self.main_widget)
+        cell_type = ctx.get("active_cell_type")
+        if not cell_type:
+            self._append_md("Select a cell type in Filtering first.")
+            return
+        action = ProposedAction("show_track_length_distribution", cell_type=cell_type)
+        action.preview = f"Show track-length distributions for {cell_type}"
+        if not apply_action(self.main_widget, action):
+            self._append_md(f"I could not open the track-length preview for **{cell_type}**.")
+
+    def _show_track_counts(self):
+        ctx = build_context(self.main_widget)
+        cell_type = ctx.get("active_cell_type")
+        if not cell_type:
+            self._append_md("Select a cell type in Filtering first.")
+            return
+        self._append_user("Cell counts by minimum track length")
+        action = ProposedAction(
+            "summarize_track_counts", cell_type=cell_type, position_t=0,
+            minimum_lengths=[20, 50, 100, 200],
         )
+        action.preview = f"Summarize track counts for {cell_type}"
+        if apply_action(self.main_widget, action) and action.data.get("result_markdown"):
+            self._append_action_result(action.data["result_markdown"])
+        else:
+            self._append_md(f"I could not calculate track counts for **{cell_type}**.")
+
+    def _choose_analysis(self):
+        self._send_intent("choose_analysis", "Choose analysis")
+
+    def _review_results(self):
+        self._send_intent("review_results", "Review results")
 
     # ------------------------------------------------------------------
     # Session replay log

--- a/behav3d/napari/_assistant_actions.py
+++ b/behav3d/napari/_assistant_actions.py
@@ -68,6 +68,7 @@ _LEAF_LABELS = {
     "step_size": "btrack step size",
     "n_workers": "worker count",
     "use_optimize": "global optimization",
+    "use_visual_features": "use visual features",
     "hypotheses": "btrack hypotheses",
     "dist_thresh": "distance threshold",
     "time_thresh": "time threshold",
@@ -567,14 +568,83 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def build_actions(raw_tool_calls: list[dict], cards: list[dict], params: dict) -> list[ProposedAction]:
+def _coerce_control_value(control: dict, value: Any) -> tuple[bool, Any, str]:
+    current = control.get("value")
+    try:
+        if isinstance(current, bool):
+            coerced = _coerce_bool(value)
+        elif isinstance(current, int):
+            coerced = int(value)
+        elif isinstance(current, float):
+            coerced = float(value)
+        elif isinstance(current, list):
+            if not isinstance(value, (list, tuple, set)):
+                return False, value, "Choose one or more values from the available options."
+            coerced = list(value)
+        else:
+            coerced = str(value)
+    except (TypeError, ValueError):
+        return False, value, f"{value!r} is not valid for {control.get('label', 'this control')}."
+    choices = control.get("choices")
+    if choices:
+        requested = coerced if isinstance(coerced, list) else [coerced]
+        resolved = []
+        for item in requested:
+            text = str(item).lower()
+            match = next((choice for choice in choices
+                          if str(choice).lower() == text
+                          or str(choice).lower().startswith(text)), None)
+            if match is None:
+                return False, coerced, f"Choose a value shown in {control.get('label', 'this control')}."
+            resolved.append(match)
+        coerced = resolved if isinstance(coerced, list) else resolved[0]
+    minimum, maximum = control.get("minimum"), control.get("maximum")
+    if minimum is not None and isinstance(coerced, (int, float)) and coerced < minimum:
+        return False, coerced, f"{control.get('label')} must be at least {minimum}."
+    if maximum is not None and isinstance(coerced, (int, float)) and coerced > maximum:
+        return False, coerced, f"{control.get('label')} must be at most {maximum}."
+    return True, coerced, ""
+
+
+def build_actions(
+    raw_tool_calls: list[dict],
+    cards: list[dict],
+    params: dict,
+    controls: list[dict] | None = None,
+) -> list[ProposedAction]:
     """Turn raw model tool-calls into validated ProposedAction objects with previews."""
     idx = _card_index(cards)
     actions: list[ProposedAction] = []
     for call in raw_tool_calls or []:
         name = call.get("name")
         args = call.get("arguments", {}) or {}
-        if name == "set_parameter":
+        if name == "set_ui_value":
+            control_id = str(args.get("control_id") or "")
+            control = next((c for c in (controls or []) if c.get("id") == control_id), None)
+            act = ProposedAction("set_ui_value", control_id=control_id,
+                                 value=args.get("value"))
+            if control is None:
+                act.ok = False
+                act.message = "That field is not available in the current interface."
+            elif not control.get("enabled", False):
+                act.ok = False
+                act.message = f"{control.get('label', 'That field')} is currently disabled."
+            elif control.get("method") and not control.get("visible", False):
+                act.ok = False
+                act.message = "That field belongs to a different method than the one selected."
+            else:
+                ok, coerced, message = _coerce_control_value(control, args.get("value"))
+                act.ok, act.message = ok, message
+                act.data.update(value=coerced, label=control.get("label"),
+                                old_value=control.get("value"))
+                act.preview = (f"{control.get('label')}: "
+                               f"{_display_value(control.get('value'))} -> {_display_value(coerced)}")
+                if ok and coerced == control.get("value"):
+                    act.ok = False
+                    act.data["no_op"] = True
+                    act.message = "This value is already set."
+            actions.append(act)
+        elif name == "set_parameter":
             key = args.get("key")
             card = idx.get(key)
             act = ProposedAction("set_parameter", key=key, value=args.get("value"))
@@ -661,6 +731,98 @@ def build_actions(raw_tool_calls: list[dict], cards: list[dict], params: dict) -
             if not value:
                 act.ok = False
                 act.message = "No segmentation method provided."
+            actions.append(act)
+        elif name == "show_track_length_distribution":
+            cell_type = str(args.get("cell_type") or "")
+            act = ProposedAction("show_track_length_distribution", cell_type=cell_type)
+            act.preview = f"Show track-length distributions for {cell_type}"
+            if not cell_type:
+                act.ok = False
+                act.message = "Choose a cell type first."
+            actions.append(act)
+        elif name == "recommend_edt":
+            cell_type = str(args.get("cell_type") or "").strip()
+            try:
+                diameter_um = float(args.get("cell_diameter_um", 10.0))
+                cells_across = args.get("organoid_cells_across")
+                cells_across = None if cells_across is None else float(cells_across)
+            except (TypeError, ValueError):
+                diameter_um, cells_across = 10.0, None
+            act = ProposedAction(
+                "recommend_edt", cell_type=cell_type,
+                cell_diameter_um=diameter_um,
+                organoid_cells_across=cells_across,
+            )
+            act.preview = f"Calculate EDT starting values for {cell_type}"
+            if not cell_type:
+                act.ok = False
+                act.message = "Choose a cell type first."
+            elif diameter_um <= 0 or (cells_across is not None and cells_across < 1):
+                act.ok = False
+                act.message = "Object size values must be greater than zero."
+            actions.append(act)
+        elif name == "summarize_track_counts":
+            cell_type = str(args.get("cell_type") or "").strip()
+            try:
+                position_t = int(args.get("position_t", 0))
+                raw_lengths = args.get("minimum_lengths") or [20, 50, 100, 200]
+                minimum_lengths = sorted({int(value) for value in raw_lengths})
+            except (TypeError, ValueError):
+                position_t, minimum_lengths = 0, []
+            act = ProposedAction(
+                "summarize_track_counts", cell_type=cell_type,
+                position_t=position_t, minimum_lengths=minimum_lengths,
+            )
+            act.preview = (
+                f"Count {cell_type} tracks at timepoint {position_t} for minimum "
+                f"lengths {minimum_lengths}"
+            )
+            if not cell_type:
+                act.ok = False
+                act.message = "Choose a cell type first."
+            elif position_t < 0:
+                act.ok = False
+                act.message = "The timepoint must be zero or greater."
+            elif not minimum_lengths or any(value < 1 for value in minimum_lengths):
+                act.ok = False
+                act.message = "Minimum track lengths must be positive integers."
+            elif len(minimum_lengths) > 20:
+                act.ok = False
+                act.message = "Compare at most 20 minimum track lengths at once."
+            actions.append(act)
+        elif name == "create_cell_type_group":
+            group_name = str(args.get("group_name") or "").strip()
+            members = [str(v) for v in (args.get("members") or [])]
+            act = ProposedAction("create_cell_type_group", group_name=group_name,
+                                 members=members)
+            act.preview = f"Create cell-type group '{group_name}' from {', '.join(members)}"
+            if not group_name or not members:
+                act.ok = False
+                act.message = "Provide a group name and at least one cell type."
+            elif not all(c.isalnum() or c in "_-" for c in group_name):
+                act.ok = False
+                act.message = "Group names may only contain letters, numbers, hyphens, and underscores."
+            actions.append(act)
+        elif name == "create_btrack_config_copy":
+            cell_type = str(args.get("cell_type") or "")
+            destination = str(args.get("destination") or "").strip()
+            act = ProposedAction("create_btrack_config_copy", cell_type=cell_type,
+                                 destination=destination)
+            act.preview = f"Create a custom btrack configuration for {cell_type} at {destination}"
+            if not cell_type or not destination:
+                act.ok = False
+                act.message = "Choose a cell type and destination file."
+            elif not destination.lower().endswith(".json"):
+                act.ok = False
+                act.message = "The custom btrack configuration must be a JSON file."
+            actions.append(act)
+        elif name == "open_result":
+            result_id = str(args.get("result_id") or "")
+            act = ProposedAction("open_result", result_id=result_id)
+            act.preview = f"Open result: {result_id}"
+            if not result_id:
+                act.ok = False
+                act.message = "Choose a result first."
             actions.append(act)
     return actions
 
@@ -752,6 +914,48 @@ def apply_set_parameter(main_widget, key: str, value: Any):
     return True, (widget is not None)
 
 
+def _values_match(actual: Any, requested: Any) -> bool:
+    if isinstance(actual, str) and isinstance(requested, str):
+        return actual.strip().lower() == requested.strip().lower() or (
+            bool(requested.strip()) and actual.strip().lower().startswith(requested.strip().lower())
+        )
+    if isinstance(actual, float) or isinstance(requested, float):
+        try:
+            return abs(float(actual) - float(requested)) < 1e-9
+        except (TypeError, ValueError):
+            pass
+    return actual == requested
+
+
+def apply_set_ui_value(main_widget, control_id: str, value: Any) -> bool:
+    """Set one exact live control and verify the value was actually applied."""
+    from behav3d.napari._assistant_controls import find_control
+
+    binding = find_control(main_widget, control_id)
+    if binding is None or not binding.get("enabled", False):
+        return False
+    setter = binding.get("_setter")
+    if setter is None or not setter(value):
+        return False
+    persist = binding.get("_persist")
+    if persist is not None:
+        try:
+            persist()
+        except Exception:
+            return False
+    refreshed = find_control(main_widget, control_id)
+    actual = refreshed.get("value") if refreshed is not None else None
+    if not _values_match(actual, value):
+        return False
+    widget = binding.get("_widget")
+    if widget is not None:
+        pulse_widget(widget)
+    dp = getattr(main_widget, "data_prep_tab", None)
+    if dp is not None:
+        _persist_params(dp)
+    return True
+
+
 def _persist_params(dp) -> None:
     import os
     out_dir = getattr(dp, "output_dir", "") or ""
@@ -808,7 +1012,9 @@ def apply_fill_metadata_builder(main_widget, action: ProposedAction) -> bool:
     try:
         if field == "open_builder":
             dp.builder_grp.setChecked(True)
-            return True
+            # Toggling can open a modal when metadata is already loaded. If the
+            # user cancels, the handler restores the unchecked state.
+            return bool(dp.builder_grp.isChecked())
         # Silently open the builder if it isn't already (non-destructive).
         if not getattr(dp.builder_grp, "isChecked", lambda: True)():
             dp.builder_grp.setChecked(True)
@@ -993,6 +1199,11 @@ def apply_action(main_widget, action: ProposedAction) -> bool:
             main_widget, action.data["key"], action.data["value"])
         action.data["widget_updated"] = visible   # dock uses this for an honest message
         return stored
+    if action.kind == "set_ui_value":
+        ok = apply_set_ui_value(main_widget, action.data["control_id"],
+                                action.data["value"])
+        action.data["widget_updated"] = ok
+        return ok
     if action.kind == "navigate_to_step":
         return apply_navigate(main_widget, action.data["step"])
     if action.kind == "add_queue_step":
@@ -1009,7 +1220,228 @@ def apply_action(main_widget, action: ProposedAction) -> bool:
         ok = apply_select_segmentation_method(main_widget, action.data.get("value"))
         action.data["widget_updated"] = ok
         return ok
+    if action.kind == "show_track_length_distribution":
+        return _apply_show_track_length_distribution(main_widget, action)
+    if action.kind == "recommend_edt":
+        return _apply_recommend_edt(main_widget, action)
+    if action.kind == "summarize_track_counts":
+        return _apply_summarize_track_counts(main_widget, action)
+    if action.kind == "create_cell_type_group":
+        return _apply_create_cell_type_group(main_widget, action)
+    if action.kind == "create_btrack_config_copy":
+        return _apply_create_btrack_config_copy(main_widget, action)
+    if action.kind == "open_result":
+        return _apply_open_result(main_widget, action)
     return False
+
+
+def _apply_show_track_length_distribution(main_widget, action: ProposedAction) -> bool:
+    tab = getattr(main_widget, "filtering_tab", None)
+    panel = (getattr(tab, "panels", {}) or {}).get(action.data.get("cell_type"))
+    callback = getattr(panel, "_on_preview_lengths_clicked", None) if panel is not None else None
+    if callback is None:
+        return False
+    callback()
+    return True
+
+
+def _apply_recommend_edt(main_widget, action: ProposedAction) -> bool:
+    dp = _dp(main_widget)
+    metadata = getattr(dp, "metadata", None) if dp is not None else None
+    try:
+        from behav3d.napari._assistant_context import _metadata_builder_state
+        builder_state = _metadata_builder_state(dp)
+    except Exception:
+        builder_state = {}
+    records = builder_state.get("draft_records") or []
+    if not records and metadata is not None and not getattr(metadata, "empty", True):
+        records = metadata.to_dict(orient="records")
+    if not records:
+        action.data["result_markdown"] = (
+            "Load or save experiment metadata first so I can read the XY pixel size."
+        )
+        return True
+
+    cell_type = action.data["cell_type"]
+    organoid_names = builder_state.get("organoid_names") or []
+    available_types = set(organoid_names)
+    available_types.update(builder_state.get("immune_names") or [])
+    available_types.update(builder_state.get("other_names") or [])
+    is_organoid = cell_type in organoid_names
+    try:
+        from behav3d.core.metadata import (
+            detect_immune_cell_types_from_metadata,
+            detect_organoid_types_from_metadata,
+            detect_other_cell_types_from_metadata,
+        )
+        if metadata is not None and not getattr(metadata, "empty", True):
+            metadata_organoids = detect_organoid_types_from_metadata(metadata)
+            is_organoid = is_organoid or cell_type in metadata_organoids
+            available_types.update(metadata_organoids)
+            available_types.update(detect_immune_cell_types_from_metadata(metadata))
+            available_types.update(detect_other_cell_types_from_metadata(metadata))
+    except Exception:
+        pass
+    if available_types and cell_type not in available_types:
+        action.data["result_markdown"] = (
+            f"I could not find **{cell_type}** in the current metadata. Choose one of: "
+            + ", ".join(sorted(available_types)) + "."
+        )
+        return True
+    cells_across = action.data.get("organoid_cells_across")
+    if is_organoid and cells_across is None:
+        action.data["result_markdown"] = (
+            f"For **{cell_type}**, approximately how many cell widths span the "
+            "organoid diameter? I will use 10 µm per cell unless you provide a "
+            "different typical cell diameter."
+        )
+        return True
+    if not is_organoid:
+        cells_across = None
+
+    try:
+        from behav3d.napari._assistant_recommendations import (
+            calculate_edt_recommendations,
+            format_edt_recommendations,
+        )
+        result = calculate_edt_recommendations(
+            records,
+            cell_diameter_um=action.data.get("cell_diameter_um", 10.0),
+            organoid_cells_across=cells_across,
+        )
+        action.data["recommendation"] = result
+        action.data["result_markdown"] = format_edt_recommendations(result, cell_type)
+        return True
+    except Exception as exc:
+        action.data["result_markdown"] = f"Could not calculate EDT values: {exc}"
+        return True
+
+
+def _apply_summarize_track_counts(main_widget, action: ProposedAction) -> bool:
+    dp = _dp(main_widget)
+    output_dir = getattr(dp, "output_dir", "") if dp is not None else ""
+    if not output_dir:
+        action.data["result_markdown"] = (
+            "Set the output directory first so I can locate the track feature CSV."
+        )
+        return True
+    try:
+        from behav3d.analysis.track_counts import (
+            format_track_count_summary,
+            generate_track_count_summary,
+        )
+        result = generate_track_count_summary(
+            output_dir,
+            action.data["cell_type"],
+            minimum_lengths=action.data["minimum_lengths"],
+            position_t=action.data["position_t"],
+        )
+        action.data["summary"] = result
+        action.data["result_markdown"] = format_track_count_summary(
+            result, action.data["cell_type"]
+        )
+        try:
+            from behav3d.napari._results_panel import notify_results_changed
+            notify_results_changed(main_widget)
+        except Exception:
+            pass
+        return True
+    except Exception as exc:
+        action.data["result_markdown"] = f"Could not calculate track counts: {exc}"
+        return True
+
+
+def _apply_create_cell_type_group(main_widget, action: ProposedAction) -> bool:
+    """Create the same metadata columns as the Feature Extraction grouping dialog."""
+    dp = _dp(main_widget)
+    md = getattr(dp, "metadata", None) if dp is not None else None
+    if md is None or getattr(md, "empty", True):
+        return False
+    group_name = action.data["group_name"]
+    members = action.data["members"]
+    try:
+        from behav3d.core.metadata import (
+            detect_immune_cell_types_from_metadata,
+            detect_merged_cell_types_from_metadata,
+            detect_organoid_types_from_metadata,
+            detect_other_cell_types_from_metadata,
+        )
+        available = set(detect_organoid_types_from_metadata(md))
+        available.update(detect_immune_cell_types_from_metadata(md))
+        available.update(detect_other_cell_types_from_metadata(md))
+        if not set(members).issubset(available):
+            return False
+        merged_name = f"{group_name}_merged"
+        if group_name in available or merged_name in set(detect_merged_cell_types_from_metadata(md)):
+            return False
+        organoids = set(detect_organoid_types_from_metadata(md))
+        immune = set(detect_immune_cell_types_from_metadata(md))
+        prefix = "or_" if any(m in organoids for m in members) else (
+            "im_" if any(m in immune for m in members) else "ot_")
+        for suffix in ("line_condition", "segments_image_path",
+                       "tracks_image_path", "tracks_csv_path"):
+            md[f"{prefix}{merged_name}_{suffix}"] = None
+        csv_path = (getattr(dp, "metadata_csv_path", None)
+                    or getattr(dp, "metadata_csv", None)
+                    or (getattr(dp, "behav3d_parameters", {}) or {})
+                    .get("paths", {}).get("metadata_csv"))
+        if csv_path:
+            md.to_csv(csv_path, index=False)
+        tab = getattr(main_widget, "feature_extraction_tab", None)
+        if tab is not None and hasattr(tab, "_on_metadata_updated"):
+            tab._on_metadata_updated()
+        return True
+    except Exception:
+        return False
+
+
+def _apply_create_btrack_config_copy(main_widget, action: ProposedAction) -> bool:
+    from pathlib import Path
+    import shutil
+
+    destination = Path(action.data["destination"]).expanduser()
+    if destination.exists():
+        return False
+    source = (Path(__file__).resolve().parents[1] / "preprocessing" / "tracking"
+              / "models" / "cell_config.json")
+    if not source.exists():
+        return False
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    except OSError:
+        return False
+    control_id = f"tracking.{action.data['cell_type']}.btrack.config_preset"
+    # Selecting Custom JSON exposes the path field; both writes are postcondition checked.
+    preset_ok = apply_set_ui_value(main_widget, control_id, "Custom JSON")
+    path_ok = apply_set_ui_value(
+        main_widget,
+        f"tracking.{action.data['cell_type']}.btrack.config_path",
+        str(destination),
+    )
+    return preset_ok and path_ok
+
+
+def _apply_open_result(main_widget, action: ProposedAction) -> bool:
+    from pathlib import Path
+    from behav3d.napari._results_catalog import scan_outputs
+
+    dp = _dp(main_widget)
+    output_dir = getattr(dp, "output_dir", "") if dp is not None else ""
+    if not output_dir:
+        return False
+    results = scan_outputs(Path(output_dir))
+    wanted = action.data["result_id"]
+    match = next((item for item in results
+                  if str(item.path.relative_to(Path(output_dir))) == wanted), None)
+    if match is None:
+        return False
+    panel = getattr(main_widget, "results_panel", None)
+    opener = getattr(panel, "_open_in_napari", None) if panel is not None else None
+    if opener is None or not match.is_viewable:
+        return False
+    opener(match)
+    return True
 
 
 def _apply_add_queue_step(main_widget, action: ProposedAction) -> bool:
@@ -1030,17 +1462,19 @@ def _apply_add_queue_step(main_widget, action: ProposedAction) -> bool:
 # ---------------------------------------------------------------------------
 TOOL_SCHEMA = [
     {
-        "name": "set_parameter",
-        "description": "Propose setting a BEHAV3D parameter. Requires user confirmation. "
-                       "Use dotted keys from the provided step_schema (e.g. "
-                       "'tracking.immune.trackpy.search_range_px').",
+        "name": "set_ui_value",
+        "description": (
+            "Set one exact field that exists in ui_state.controls. Use its id exactly. "
+            "Never invent an id and never use internal configuration keys. Blank fields "
+            "may apply immediately; changing an existing value requires confirmation."
+        ),
         "parameters": {
             "type": "object",
             "properties": {
-                "key": {"type": "string"},
+                "control_id": {"type": "string"},
                 "value": {},
             },
-            "required": ["key", "value"],
+            "required": ["control_id", "value"],
         },
     },
     {
@@ -1176,17 +1610,104 @@ TOOL_SCHEMA = [
         },
     },
     {
-        "name": "select_segmentation_method",
+        "name": "recommend_edt",
         "description": (
-            "Select the global Segmentation Method dropdown on the Segmentation tab "
-            "(this swaps the visible parameter page). Use the leading visible label: "
-            "'APOC', 'ConvPaint', 'Pixel Classifier', 'Cellpose', or "
-            "'Import segmentation'."
+            "Calculate EDT/watershed starting values from each sample's metadata XY "
+            "resolution. For ordinary cells, use the default 10 um diameter unless "
+            "the user provides another value. For organoids, first ask approximately "
+            "how many cell widths span the organoid diameter, then pass that number as "
+            "organoid_cells_across. This action reports recommendations but does not "
+            "change the EDT field."
         ),
         "parameters": {
             "type": "object",
-            "properties": {"value": {"type": "string"}},
-            "required": ["value"],
+            "properties": {
+                "cell_type": {"type": "string"},
+                "cell_diameter_um": {
+                    "type": "number", "default": 10,
+                    "description": "Typical diameter of one cell in micrometers.",
+                },
+                "organoid_cells_across": {
+                    "type": "number",
+                    "description": (
+                        "Approximate number of cell widths across the organoid diameter. "
+                        "Required for organoid recommendations."
+                    ),
+                },
+            },
+            "required": ["cell_type"],
+        },
+    },
+    {
+        "name": "summarize_track_counts",
+        "description": (
+            "Read the unfiltered combined track-features CSV, count unique tracks "
+            "present at one position_t, compare minimum track-length thresholds, and "
+            "save the resulting sample-by-threshold table under quality_control. Use "
+            "this for both the standard 20/50/100/200 summary and arbitrary interactive "
+            "threshold or timepoint questions."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "cell_type": {"type": "string"},
+                "position_t": {"type": "integer", "minimum": 0, "default": 0},
+                "minimum_lengths": {
+                    "type": "array",
+                    "items": {"type": "integer", "minimum": 1},
+                    "maxItems": 20,
+                    "default": [20, 50, 100, 200],
+                },
+            },
+            "required": ["cell_type"],
+        },
+    },
+    {
+        "name": "show_track_length_distribution",
+        "description": "Open the existing track-length distribution preview for one cell type.",
+        "parameters": {
+            "type": "object",
+            "properties": {"cell_type": {"type": "string"}},
+            "required": ["cell_type"],
+        },
+    },
+    {
+        "name": "create_cell_type_group",
+        "description": (
+            "Create a merged cell-type group in metadata. This changes the metadata CSV "
+            "and therefore always requires confirmation. It does not require re-tracking."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "group_name": {"type": "string"},
+                "members": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["group_name", "members"],
+        },
+    },
+    {
+        "name": "create_btrack_config_copy",
+        "description": (
+            "Copy the bundled cell btrack configuration to a new JSON file and select "
+            "it for one cell type. File creation always requires confirmation."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "cell_type": {"type": "string"},
+                "destination": {"type": "string"},
+            },
+            "required": ["cell_type", "destination"],
+        },
+    },
+    {
+        "name": "open_result",
+        "description": "Open a viewable result listed in context.results using its exact id.",
+        "parameters": {
+            "type": "object",
+            "properties": {"result_id": {"type": "string"}},
+            "required": ["result_id"],
         },
     },
 ]

--- a/behav3d/napari/_assistant_client.py
+++ b/behav3d/napari/_assistant_client.py
@@ -84,13 +84,17 @@ class LocalResponder:
             hits = [c for s, c in scored[:3] if s > 0]
         if not hits:
             return ("⚠️ Offline mode (no assistant server reachable). I can only "
-                    "answer parameter questions locally. Try naming a parameter, "
-                    "e.g. “what is search_range_px?”")
+                    "answer field questions locally. Try asking, for example, "
+                    "“What does search range mean?”")
         lines = ["⚠️ *Offline mode* — answering from the local parameter schema:\n"]
+        from behav3d.napari._assistant_actions import humanize_parameter_key
         for c in hits[:3]:
             dv = c.get("default")
             ch = f" Choices: {c['choices']}." if c.get("choices") else ""
-            lines.append(f"**{c['key']}** (default `{dv}`)\n{c['description']}{ch}\n")
+            lines.append(
+                f"**{humanize_parameter_key(c['key'])}** (default `{dv}`)\n"
+                f"{c['description']}{ch}\n"
+            )
         return "\n".join(lines)
 
 

--- a/behav3d/napari/_assistant_context.py
+++ b/behav3d/napari/_assistant_context.py
@@ -32,7 +32,14 @@ The returned dict shape:
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Optional
+
+from behav3d.napari._assistant_controls import (
+    CONTROL_CONTRACT_VERSION,
+    active_cell_type,
+    control_registry,
+)
 
 # Tab index -> workflow step key (mirrors the order tabs are added in _widget.py)
 _TAB_INDEX_TO_STEP = {
@@ -53,8 +60,97 @@ def _safe(fn, default=None):
         return default
 
 
+_DIMENSION_ORDERS = {"TCZYX", "TZCYX", "ZCTYX", "ZTCYX", "CZTYX", "CTZYX"}
+_RAW_IMAGE_SUFFIXES = (".zarr", ".zarr.zip", ".czi", ".lif", ".liff",
+                       ".tif", ".tiff", ".ims", ".h5")
+
+
+def _json_value(value):
+    """Convert pandas/numpy/path values to JSON primitives without hiding data."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_value(item) for item in value]
+    try:
+        import pandas as pd
+        if bool(pd.isna(value)):
+            return None
+    except (ImportError, TypeError, ValueError):
+        pass
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "item"):
+        return _safe(value.item, str(value))
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def validate_metadata_records(records: list[dict]) -> list[dict]:
+    """Return factual metadata issues and review notes without biological guesses."""
+    issues: list[dict] = []
+
+    def add(row, field, severity, message):
+        issues.append({"row": row, "field": field, "severity": severity,
+                       "message": message})
+
+    required = ("sample_name", "raw_image_path", "pixel_distance_xy",
+                "pixel_distance_z", "time_interval")
+    for index, record in enumerate(records):
+        sample = record.get("sample_name") or f"row {index + 1}"
+        for field in required:
+            value = record.get(field)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                add(index, field, "error", f"{sample}: {field.replace('_', ' ')} is missing.")
+
+        raw = str(record.get("raw_image_path") or "").strip()
+        if raw:
+            path = Path(raw).expanduser()
+            lower = raw.lower()
+            if path.is_dir() and not lower.endswith(".zarr"):
+                add(index, "raw_image_path", "error",
+                    f"{sample}: the raw image path is a folder; select one multidimensional image file.")
+            elif not any(lower.endswith(suffix) for suffix in _RAW_IMAGE_SUFFIXES):
+                add(index, "raw_image_path", "error",
+                    f"{sample}: the raw image format is not supported by the loader.")
+            elif not path.exists():
+                add(index, "raw_image_path", "warning",
+                    f"{sample}: the raw image path does not exist on this machine.")
+
+        order = str(record.get("dimension_order") or "").strip().upper()
+        if order and order not in _DIMENSION_ORDERS:
+            add(index, "dimension_order", "error",
+                f"{sample}: dimension order must be one of {', '.join(sorted(_DIMENSION_ORDERS))}.")
+        for field in ("pixel_distance_xy", "pixel_distance_z", "time_interval"):
+            value = record.get(field)
+            if value is None or value == "":
+                continue
+            try:
+                if float(value) <= 0:
+                    add(index, field, "error",
+                        f"{sample}: {field.replace('_', ' ')} must be greater than zero.")
+            except (TypeError, ValueError):
+                add(index, field, "error",
+                    f"{sample}: {field.replace('_', ' ')} must be numeric.")
+
+    names = [str(r.get("sample_name") or "").strip() for r in records]
+    duplicates = sorted({name for name in names if name and names.count(name) > 1})
+    for name in duplicates:
+        add(None, "sample_name", "error", f"Sample name '{name}' is used more than once.")
+
+    for field in ("pixel_distance_xy", "pixel_distance_z", "time_interval",
+                  "time_unit", "dimension_order"):
+        values = {_json_value(r.get(field)) for r in records if r.get(field) not in (None, "")}
+        if len(values) > 1:
+            add(None, field, "review",
+                f"{field.replace('_', ' ').capitalize()} differs between samples; verify that this is intentional.")
+    return issues
+
+
 def summarize_metadata(metadata) -> dict:
-    """Summarise a metadata DataFrame without assuming any column exists."""
+    """Serialize every loaded metadata row and validate researcher-facing fields."""
     if metadata is None:
         return {"loaded": False}
     try:
@@ -90,12 +186,21 @@ def summarize_metadata(metadata) -> dict:
     except Exception:
         cell_types = {}
 
+    records = []
+    try:
+        for _index, row in metadata.iterrows():
+            records.append({str(column): _json_value(row.get(column)) for column in columns})
+    except Exception:
+        records = []
+
     return {
         "loaded": True,
         "n_samples": n_samples,
         "sample_names": sample_names,
         "columns": columns,
         "cell_types": cell_types,
+        "records": records,
+        "validation": validate_metadata_records(records),
     }
 
 
@@ -136,6 +241,41 @@ def serialize_queue(queue_panel) -> list[dict]:
             "params": _safe(lambda s=step: dict(s.params), {}) or {},
         })
     return out
+
+
+def _serialize_results(output_dir: str) -> list[dict]:
+    if not output_dir:
+        return []
+    try:
+        from behav3d.napari._results_catalog import scan_outputs
+        root = Path(output_dir).expanduser()
+        return [{
+            "id": str(item.path.relative_to(root)),
+            "label": item.label,
+            "description": item.description,
+            "kind": item.kind,
+            "category": item.category,
+            "subcategory": item.subcategory,
+            "cell_type": item.cell_type,
+            "viewable": item.is_viewable,
+        } for item in scan_outputs(root)]
+    except Exception:
+        return []
+
+
+def _active_preview(main_widget) -> dict | None:
+    feature_tab = getattr(main_widget, "feature_extraction_tab", None)
+    for cell_type, panel in (getattr(feature_tab, "panels", {}) or {}).items():
+        if getattr(panel, "_preview_seg_t", None) is not None:
+            return {
+                "type": "dead_threshold",
+                "cell_type": cell_type,
+                "sample": _widget_value(getattr(panel, "preview_sample_combo", None)),
+                "threshold_percent": _widget_value(getattr(panel, "spin_dead_threshold", None)),
+                "overlay": "green cells are alive; red cells are dead",
+                "hover": "hover a cell to see its dead-mask percentage",
+            }
+    return None
 
 
 def _widget_value(widget):
@@ -179,7 +319,8 @@ def _metadata_builder_state(dp) -> dict:
         n_oth = len(getattr(dp, "_other_name_edits", []))
         forms = getattr(dp, "_sample_forms", []) or []
         sample_forms = []
-        for idx, form in enumerate(forms[:5]):
+        draft_records = []
+        for idx, form in enumerate(forms):
             basic = _clean_widget_values({
                 k: _widget_value(w) for k, w in (form.get("basic") or {}).items()
             })
@@ -198,6 +339,14 @@ def _metadata_builder_state(dp) -> dict:
                 "dead_channel": dead,
                 "cell_types": cell_types,
             })
+            record = dict(basic)
+            if "number" in dead:
+                record["dead_channel"] = dead["number"]
+            if "mask_path" in dead:
+                record["dead_mask_path"] = dead["mask_path"]
+            if cell_types:
+                record["cell_types"] = cell_types
+            draft_records.append(record)
 
         return {
             "open": bool(getattr(dp, "builder_grp", None) and dp.builder_grp.isChecked()),
@@ -213,6 +362,12 @@ def _metadata_builder_state(dp) -> dict:
             "immune_names": [e.text() for e in getattr(dp, "_immune_name_edits", [])],
             "other_names": [e.text() for e in getattr(dp, "_other_name_edits", [])],
             "sample_forms": sample_forms,
+            # These values are the live form draft and can be newer than
+            # dp.metadata while an existing CSV is being edited.
+            "draft_records": draft_records,
+            "draft_validation": validate_metadata_records(draft_records) if draft_records else [],
+            "record_source": "metadata_builder_draft" if draft_records else None,
+            "save_required": bool(draft_records),
         }
     except Exception:
         return {"open": False}
@@ -279,30 +434,6 @@ def _step_readiness(main_widget, ctx: dict) -> dict:
     return steps
 
 
-def _active_cell_type_tab(main_widget, step: str) -> str | None:
-    """Return 'immune', 'organoid', or 'other' for the active cell-type sub-tab."""
-    tab_attr = {
-        "tracking": "tracking_tab",
-        "feature_extraction": "feature_extraction_tab",
-        "filtering": "filtering_tab",
-    }.get(step)
-    if tab_attr is None:
-        return None
-    tab_widget = _safe(lambda: getattr(main_widget, tab_attr, None))
-    if tab_widget is None:
-        return None
-    panels_tab = _safe(lambda: getattr(tab_widget, "panels_tab", None) or
-                       getattr(tab_widget, "tab_widget", None))
-    if panels_tab is None:
-        return None
-    idx = _safe(lambda: panels_tab.currentIndex(), 0)
-    label = _safe(lambda: panels_tab.tabText(idx).lower(), "")
-    for ct in ("immune", "organoid", "other"):
-        if ct in label:
-            return ct
-    return None
-
-
 def _segmentation_state(main_widget) -> dict:
     """Snapshot the visible segmentation method selector."""
     seg = _safe(lambda: getattr(main_widget, "segmentation_tab", None))
@@ -359,14 +490,34 @@ def build_context(main_widget) -> dict:
     queue_panel = getattr(main_widget, "queue_panel", None)
     queue = serialize_queue(queue_panel) if queue_panel is not None else []
 
+    metadata_summary = summarize_metadata(metadata)
+    builder_state = _safe(lambda: _metadata_builder_state(dp), {"open": False}) or {
+        "open": False
+    }
+    draft_records = builder_state.get("draft_records") or []
+    if draft_records:
+        # Questions about current form entries must use the draft. Otherwise an
+        # older loaded DataFrame can make the assistant repeat a completed change.
+        metadata_summary["records"] = draft_records
+        metadata_summary["validation"] = builder_state.get("draft_validation", [])
+        metadata_summary["n_samples"] = len(draft_records)
+        metadata_summary["sample_names"] = [
+            str(record.get("sample_name")) for record in draft_records
+            if record.get("sample_name") not in (None, "")
+        ]
+        metadata_summary["record_source"] = "metadata_builder_draft"
+        metadata_summary["save_required"] = True
+
     ctx = {
         "current_step": step,
         "current_tab_label": tab_label,
         "tab_index": tab_index,
         "output_dir": output_dir,
         "output_dir_set": bool(output_dir),
-        "metadata": summarize_metadata(metadata),
+        "metadata": metadata_summary,
         "queue": queue,
+        "results": _safe(lambda: _serialize_results(output_dir), []) or [],
+        "active_preview": _safe(lambda: _active_preview(main_widget), None),
         "parameters": _safe(lambda: _diff_from_defaults(params), {}) or {},
         # The Visualization tab is a viewer with no tunable BEHAV3D parameters that
         # have visible widgets (its schema cards — use_range/start_t/end_t/
@@ -375,16 +526,23 @@ def build_context(main_widget) -> dict:
         "step_schema": [] if step == "visualization"
                        else (_safe(lambda: cards_for_step(step), []) or []),
     }
-    # Include metadata builder state only when on the data_preparation tab.
-    if step == "data_preparation":
-        ctx["metadata_builder"] = _metadata_builder_state(dp)
+    # Keep an open/drafted builder visible even after a tab switch. This avoids
+    # regressing to the stale saved DataFrame on the next assistant turn.
+    if (step == "data_preparation" or builder_state.get("open")
+            or builder_state.get("sample_forms_created")):
+        ctx["metadata_builder"] = builder_state
     if step == "segmentation":
         ctx["segmentation"] = _safe(lambda: _segmentation_state(main_widget), {})
 
+    controls = _safe(lambda: control_registry(main_widget), []) or []
+    ctx["ui_state"] = {
+        "contract_version": CONTROL_CONTRACT_VERSION,
+        "controls": controls,
+    }
+
     # Guided-flow enrichments.
     ctx["step_readiness"] = _safe(lambda: _step_readiness(main_widget, ctx), {})
-    ctx["active_cell_type_tab"] = _safe(
-        lambda: _active_cell_type_tab(main_widget, step), None)
+    ctx["active_cell_type"] = _safe(lambda: active_cell_type(main_widget, step), None)
     ctx["required_params_at_default"] = _safe(
         lambda: _required_params_at_default(step, ctx["step_schema"], params), [])
     return ctx
@@ -397,4 +555,11 @@ def context_summary_line(ctx: dict) -> str:
     out_ok = "output set" if ctx.get("output_dir_set") else "no output dir"
     nq = len(ctx.get("queue", []))
     step = ctx.get("current_tab_label") or ctx.get("current_step", "")
-    return f"📍 {step} · {n} sample(s) · {out_ok} · {nq} queued"
+    details = [str(step), f"{n} sample(s)", out_ok, f"{nq} queued"]
+    active = ctx.get("active_cell_type")
+    if active:
+        details.insert(1, str(active))
+    method = (ctx.get("segmentation") or {}).get("method")
+    if method:
+        details.insert(1, str(method).split("(")[0].strip())
+    return "  |  ".join(details)

--- a/behav3d/napari/_assistant_controls.py
+++ b/behav3d/napari/_assistant_controls.py
@@ -1,0 +1,544 @@
+"""Live UI control contract used by the BEHAV3D assistant.
+
+The assistant may only edit controls returned by :func:`control_bindings`.
+Keeping context serialization and action application on this same registry
+prevents stale config keys from being mistaken for fields on the screen.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+CONTROL_CONTRACT_VERSION = "2.0"
+
+
+def _safe(fn: Callable, default=None):
+    try:
+        return fn()
+    except Exception:
+        return default
+
+
+def _widget_value(widget):
+    if widget is None:
+        return None
+    if hasattr(widget, "isChecked"):
+        return _safe(widget.isChecked)
+    if hasattr(widget, "currentText"):
+        return _safe(widget.currentText)
+    if hasattr(widget, "value"):
+        return _safe(widget.value)
+    if hasattr(widget, "text"):
+        return _safe(widget.text)
+    return None
+
+
+def _widget_choices(widget) -> list[str] | None:
+    if widget is None or not hasattr(widget, "count") or not hasattr(widget, "itemText"):
+        return None
+    return [_safe(lambda i=i: str(widget.itemText(i)), "") for i in range(widget.count())]
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def set_widget_value(widget, value: Any) -> bool:
+    """Set a common Qt input using duck typing so this module stays testable."""
+    if widget is None:
+        return False
+    try:
+        if hasattr(widget, "setChecked") and hasattr(widget, "isChecked"):
+            widget.setChecked(_coerce_bool(value))
+            return True
+        if hasattr(widget, "setCurrentIndex") and hasattr(widget, "itemText"):
+            wanted = str(value).strip().lower()
+            choices = _widget_choices(widget) or []
+            matches = [
+                i for i, label in enumerate(choices)
+                if label.lower() == wanted or label.lower().startswith(wanted)
+            ]
+            if not matches:
+                matches = [i for i, label in enumerate(choices) if wanted in label.lower()]
+            if not matches:
+                return False
+            widget.setCurrentIndex(matches[0])
+            return True
+        if hasattr(widget, "setValue") and hasattr(widget, "value"):
+            current = widget.value()
+            widget.setValue(int(value) if isinstance(current, int) and not isinstance(current, bool)
+                            else float(value))
+            return True
+        if hasattr(widget, "setText"):
+            widget.setText(str(value))
+            return True
+    except (TypeError, ValueError):
+        return False
+    return False
+
+
+def _is_visible(widget) -> bool:
+    if widget is None:
+        return False
+    return not bool(_safe(widget.isHidden, False)) if hasattr(widget, "isHidden") else True
+
+
+def _is_enabled(widget) -> bool:
+    return bool(_safe(widget.isEnabled, True)) if widget is not None else False
+
+
+def _binding(
+    control_id: str,
+    label: str,
+    widget,
+    *,
+    step: str,
+    default: Any = None,
+    unit: str | None = None,
+    method: str | None = None,
+    cell_type: str | None = None,
+    visible: bool | None = None,
+    getter: Callable | None = None,
+    setter: Callable | None = None,
+    persist: Callable | None = None,
+) -> dict:
+    get = getter or (lambda w=widget: _widget_value(w))
+    set_ = setter or (lambda value, w=widget: set_widget_value(w, value))
+    choices = _widget_choices(widget)
+    record = {
+        "id": control_id,
+        "label": label,
+        "value": _safe(get),
+        "default": default,
+        "unit": unit,
+        "choices": choices,
+        "visible": _is_visible(widget) if visible is None else bool(visible),
+        "enabled": _is_enabled(widget),
+        "step": step,
+        "method": method,
+        "cell_type": cell_type,
+        "_widget": widget,
+        "_getter": get,
+        "_setter": set_,
+        "_persist": persist,
+    }
+    for name, attr in (("minimum", "minimum"), ("maximum", "maximum")):
+        if widget is not None and hasattr(widget, attr):
+            record[name] = _safe(getattr(widget, attr))
+    return record
+
+
+def _checkset_binding(control_id, label, checks, **kwargs):
+    checks = checks or {}
+
+    def get():
+        return [name for name, check in checks.items() if _safe(check.isChecked, False)]
+
+    def set_(value):
+        if not isinstance(value, (list, tuple, set)):
+            return False
+        selected = {str(item) for item in value}
+        if not selected.issubset(set(checks)):
+            return False
+        for name, check in checks.items():
+            if _is_enabled(check):
+                check.setChecked(name in selected)
+        return True
+
+    first = next(iter(checks.values()), None)
+    item = _binding(control_id, label, first, getter=get, setter=set_, **kwargs)
+    item["choices"] = list(checks)
+    item["enabled"] = any(_is_enabled(check) for check in checks.values())
+    return item
+
+
+def _metadata_bindings(main_widget) -> list[dict]:
+    dp = getattr(main_widget, "data_prep_tab", None)
+    if dp is None:
+        return []
+    out = []
+    def set_output_dir(value):
+        widget = getattr(dp, "output_dir_edit", None)
+        if not set_widget_value(widget, value):
+            return False
+        dp.output_dir = str(value)
+        params = getattr(dp, "behav3d_parameters", None)
+        if isinstance(params, dict):
+            params.setdefault("paths", {})["output_dir"] = str(value)
+        return True
+
+    globals_ = [
+        ("data.output_directory", "Output directory", getattr(dp, "output_dir_edit", None),
+         set_output_dir),
+        ("data.metadata_csv", "Metadata CSV", getattr(dp, "csv_path_edit", None), None),
+        ("data.dimension_order_all", "Dimension order for all samples",
+         getattr(dp, "dim_apply_all_combo", None), None),
+    ]
+    for cid, label, widget, setter in globals_:
+        if widget is not None:
+            out.append(_binding(cid, label, widget, step="data_preparation", setter=setter))
+
+    builder = [
+        ("metadata.number_of_samples", "Number of samples", "n_samples_spin", 1),
+        ("metadata.number_of_organoid_types", "Number of organoid types", "n_organoid_spin", 0),
+        ("metadata.number_of_immune_types", "Number of immune cell types", "n_immune_spin", 0),
+        ("metadata.number_of_other_types", "Number of other cell types", "n_other_spin", 0),
+        ("metadata.include_dead_channel", "Include a dead-cell channel", "include_dead_cb", False),
+    ]
+    for cid, label, attr, default in builder:
+        widget = getattr(dp, attr, None)
+        if widget is not None:
+            out.append(_binding(cid, label, widget, step="data_preparation", default=default))
+
+    basic_labels = {
+        "sample_name": "Sample name", "exp_nr": "Experiment number", "well": "Well",
+        "raw_image_path": "Raw image path", "dimension_order": "Dimension order",
+        "pixel_distance_xy": "Pixel size XY", "pixel_distance_z": "Pixel size Z",
+        "time_interval": "Time interval", "time_unit": "Time unit",
+    }
+    units = {"pixel_distance_xy": "um", "pixel_distance_z": "um"}
+    for index, form in enumerate(getattr(dp, "_sample_forms", []) or []):
+        for field, widget in (form.get("basic") or {}).items():
+            out.append(_binding(
+                f"metadata.samples.{index}.{field}",
+                f"Sample {index + 1}: {basic_labels.get(field, field.replace('_', ' '))}",
+                widget, step="data_preparation", unit=units.get(field),
+            ))
+        for field, widget in (form.get("dead_channel") or {}).items():
+            suffix = "dead_channel" if field == "number" else "dead_mask_path"
+            label = "Dead channel number" if field == "number" else "Dead mask path"
+            out.append(_binding(f"metadata.samples.{index}.{suffix}",
+                                f"Sample {index + 1}: {label}", widget,
+                                step="data_preparation"))
+        for cell_type, fields in (form.get("cell_types") or {}).items():
+            for field, widget in fields.items():
+                out.append(_binding(
+                    f"metadata.samples.{index}.cell_types.{cell_type}.{field}",
+                    f"Sample {index + 1}, {cell_type}: {field.replace('_', ' ')}",
+                    widget, step="data_preparation", cell_type=str(cell_type),
+                ))
+    return out
+
+
+def _segmentation_bindings(main_widget) -> list[dict]:
+    seg = getattr(main_widget, "segmentation_tab", None)
+    combo = getattr(seg, "method_combo", None) if seg is not None else None
+    if combo is None:
+        return []
+    current_index = _safe(combo.currentIndex, 0)
+    out = [_binding("segmentation.method", "Segmentation method", combo,
+                    step="segmentation")]
+    pages = [
+        (0, "apoc", "APOC", "apoc_page"),
+        (1, "convpaint", "ConvPaint", "convpaint_page"),
+        (2, "random_forest", "Pixel Classifier (Random Forest)", "pixel_classifier_page"),
+    ]
+    for index, token, method, attr in pages:
+        page = getattr(seg, attr, None)
+        widget = getattr(page, "spin_examples", None) if page is not None else None
+        if widget is not None:
+            persist_name = {
+                "apoc": "_save_apoc_params_to_yaml",
+                "convpaint": "_save_params_to_yaml",
+                "random_forest": "_persist_params",
+            }[token]
+            out.append(_binding(
+                f"segmentation.{token}.examples_per_sample",
+                f"{method}: examples per sample", widget,
+                step="segmentation", default=3, method=method,
+                visible=current_index == index,
+                persist=getattr(page, persist_name, None),
+            ))
+
+    # EDT fields are created dynamically per cell type and per strategy. Expose
+    # only fields that currently exist, using the same binding for context and
+    # application so recommendations can be applied to the exact visible method.
+    apoc = getattr(seg, "apoc_page", None)
+    apoc_training = getattr(apoc, "_training_widget", None) if apoc is not None else None
+    for cell_type, tab in (getattr(apoc_training, "tabs", {}) or {}).items():
+        widget = getattr(tab, "edt_threshold_spin", None)
+        if widget is None:
+            continue
+
+        def persist_apoc(page=apoc):
+            page._save_apoc_params_to_yaml(
+                updated_apoc_params=page._collect_apoc_tab_config()
+            )
+
+        out.append(_binding(
+            f"segmentation.apoc.{cell_type}.edt_threshold",
+            f"{cell_type}: APOC EDT threshold", widget,
+            step="segmentation", unit="pixels", method="APOC",
+            cell_type=str(cell_type), visible=current_index == 0,
+            persist=persist_apoc,
+        ))
+
+    convpaint = getattr(seg, "convpaint_page", None)
+    conv_training = (
+        getattr(convpaint, "_training_widget", None) if convpaint is not None else None
+    )
+    for cell_type, tab in (getattr(conv_training, "tabs", {}) or {}).items():
+        widget = getattr(tab, "edt_threshold_spin", None)
+        if widget is None:
+            continue
+        out.append(_binding(
+            f"segmentation.convpaint.{cell_type}.edt_threshold",
+            f"{cell_type}: ConvPaint EDT threshold", widget,
+            step="segmentation", unit="pixels", method="ConvPaint",
+            cell_type=str(cell_type), visible=current_index == 1,
+            persist=(lambda page=convpaint, training_tab=tab:
+                     page._save_params_to_yaml(training_tab.collect_params())),
+        ))
+
+    random_forest = getattr(seg, "pixel_classifier_page", None)
+    for cell_type, widgets in (getattr(random_forest, "param_widgets", {}) or {}).items():
+        widget = (widgets or {}).get("edt")
+        if widget is None:
+            continue
+        out.append(_binding(
+            f"segmentation.random_forest.{cell_type}.edt_threshold",
+            f"{cell_type}: Pixel Classifier EDT threshold", widget,
+            step="segmentation", unit="pixels",
+            method="Pixel Classifier (Random Forest)", cell_type=str(cell_type),
+            visible=current_index == 2,
+            persist=getattr(random_forest, "_persist_params", None),
+        ))
+    cellpose = getattr(seg, "cellpose_page", None)
+    channels = getattr(cellpose, "spin_manual_channels", None) if cellpose is not None else None
+    if channels is not None:
+        out.append(_binding("segmentation.cellpose.number_of_channels",
+                            "Cellpose: number of channels", channels,
+                            step="segmentation", method="Cellpose",
+                            visible=current_index == 3,
+                            persist=getattr(cellpose, "_persist_channel_config", None)))
+    return out
+
+
+def _tracking_bindings(main_widget) -> list[dict]:
+    tab = getattr(main_widget, "tracking_tab", None)
+    panels = getattr(tab, "panels", {}) or {} if tab is not None else {}
+    out = []
+    specs = [
+        ("method", "Tracking method", "combo_method", None, None),
+        ("lap.frame_link_distance", "LAP frame-to-frame linking distance", "lap_track_cost", "px", "LAP"),
+        ("lap.gap_closing_distance", "LAP gap-closing distance", "lap_gap_cost", "px", "LAP"),
+        ("lap.maximum_gap", "LAP maximum gap", "lap_gap_frames", "frames", "LAP"),
+        ("lap.merging_distance", "LAP merging distance", "lap_merge_cost", "px", "LAP"),
+        ("lap.splitting_distance", "LAP splitting distance", "lap_split_cost", "px", "LAP"),
+        ("trackpy.search_range", "TrackPy search range", "tp_search_range", "px", "TrackPy"),
+        ("trackpy.memory", "TrackPy memory", "tp_memory", "frames", "TrackPy"),
+        ("trackpy.adaptive_stop", "TrackPy adaptive stop", "tp_adaptive_stop", "px", "TrackPy"),
+        ("trackpy.adaptive_step", "TrackPy adaptive step", "tp_adaptive_step", None, "TrackPy"),
+        ("btrack.config_preset", "btrack configuration preset", "bt_config_preset", None, "btrack"),
+        ("btrack.config_path", "btrack custom configuration", "bt_config_path", None, "btrack"),
+        ("btrack.maximum_search_radius", "btrack maximum search radius", "bt_max_search_radius", "um", "btrack"),
+        ("btrack.update_method", "btrack update method", "bt_update_method", None, "btrack"),
+        ("btrack.step_size", "btrack step size", "bt_step_size", "frames", "btrack"),
+        ("btrack.use_visual_features", "Use visual features", "bt_use_visual_features", None, "btrack"),
+        ("btrack.workers", "btrack workers", "bt_n_workers", None, "btrack"),
+        ("btrack.use_global_optimization", "Enable global track optimization", "bt_use_optimize", None, "btrack"),
+        ("btrack.distance_threshold", "btrack optimizer distance threshold", "bt_dist_thresh", "um", "btrack"),
+        ("btrack.time_threshold", "btrack optimizer time threshold", "bt_time_thresh", "frames", "btrack"),
+    ]
+    for cell_type, panel in panels.items():
+        method_index = _safe(panel.combo_method.currentIndex, 0)
+        for suffix, label, attr, unit, method in specs:
+            widget = getattr(panel, attr, None)
+            if widget is None:
+                continue
+            visible = True
+            if method == "LAP":
+                visible = method_index == 0
+            elif method == "TrackPy":
+                visible = method_index == 1
+            elif method == "btrack":
+                visible = method_index == 3
+            out.append(_binding(f"tracking.{cell_type}.{suffix}",
+                                f"{cell_type}: {label}", widget, step="tracking",
+                                unit=unit, method=method, cell_type=str(cell_type),
+                                visible=visible, persist=getattr(panel, "_persist", None)))
+        checks = getattr(panel, "bt_hyp_checks", {}) or {}
+        if checks:
+            out.append(_checkset_binding(
+                f"tracking.{cell_type}.btrack.hypotheses",
+                f"{cell_type}: btrack optimization hypotheses", checks,
+                step="tracking", method="btrack", cell_type=str(cell_type),
+                visible=method_index == 3, persist=getattr(panel, "_persist", None),
+            ))
+    return out
+
+
+def _feature_bindings(main_widget) -> list[dict]:
+    tab = getattr(main_widget, "feature_extraction_tab", None)
+    panels = getattr(tab, "panels", {}) or {} if tab is not None else {}
+    out = []
+    for cell_type, panel in panels.items():
+        checks = getattr(panel, "feature_checks", {}) or {}
+        if checks:
+            out.append(_checkset_binding(f"features.{cell_type}.feature_groups",
+                                         f"{cell_type}: feature groups", checks,
+                                         step="feature_extraction", cell_type=str(cell_type),
+                                         persist=getattr(panel, "_persist", None)))
+        for suffix, label, attr, unit in [
+            ("contact_distance", "contact distance", "contact_threshold", "um"),
+            ("dead_pixel_threshold", "dead-pixel threshold", "spin_dead_threshold", "%"),
+            ("workers", "workers", "spin_workers", None),
+        ]:
+            widget = getattr(panel, attr, None)
+            if widget is not None:
+                out.append(_binding(f"features.{cell_type}.{suffix}",
+                                    f"{cell_type}: {label}", widget,
+                                    step="feature_extraction", unit=unit,
+                                    cell_type=str(cell_type), persist=getattr(panel, "_persist", None)))
+    return out
+
+
+def _filter_bindings(main_widget) -> list[dict]:
+    tab = getattr(main_widget, "filtering_tab", None)
+    panels = getattr(tab, "panels", {}) or {} if tab is not None else {}
+    out = []
+    specs = [
+        ("trim_to_maximum.enabled", "Trim full time series", "en_exp_duration", None),
+        ("trim_to_maximum.timepoints", "Maximum timepoints", "spin_exp_duration", "timepoints"),
+        ("minimum_length.enabled", "Filter short tracks", "en_min_length", None),
+        ("minimum_length.timepoints", "Minimum track length", "spin_min_length", "timepoints"),
+        ("maximum_length.enabled", "Trim long tracks", "en_max_length", None),
+        ("maximum_length.timepoints", "Maximum track length", "spin_max_length", "timepoints"),
+        ("minimum_initial_size.enabled", "Filter by initial size", "check_filter_min_size", None),
+        ("minimum_initial_size.pixels", "Minimum initial size", "spin_min_size_t1", "pixels"),
+        ("dead_at_first_timepoint.enabled", "Filter dead cells at first timepoint", "check_filter_dead_t0", None),
+        ("time_unit", "Filtering time unit", "combo_time_type", None),
+    ]
+    for cell_type, panel in panels.items():
+        for suffix, label, attr, unit in specs:
+            widget = getattr(panel, attr, None)
+            if widget is not None:
+                out.append(_binding(f"filtering.{cell_type}.{suffix}",
+                                    f"{cell_type}: {label}", widget, step="filtering",
+                                    unit=unit, cell_type=str(cell_type),
+                                    persist=getattr(panel, "_persist", None)))
+    return out
+
+
+def _analysis_bindings(main_widget) -> list[dict]:
+    analysis = getattr(main_widget, "analysis_tab", None)
+    single = getattr(analysis, "single_cell_tab", None) if analysis is not None else None
+    state = getattr(single, "state_tab", None) if single is not None else None
+    if state is None:
+        return []
+    cell_type = _safe(single.cell_type_combo.currentText, "") or None
+    out = []
+    persist = ((lambda ct=cell_type: state._persist_state_cfg(ct))
+               if cell_type else None)
+    mode_combo = getattr(state, "combo_hmm_n_states_mode", None)
+    sticky_check = getattr(state, "chk_hmm_sticky", None)
+    mode = _safe(mode_combo.currentText, "fixed") if mode_combo is not None else "fixed"
+    sticky = bool(_safe(sticky_check.isChecked, False)) if sticky_check is not None else False
+    specs = [
+        ("window_size", "Window size", "spin_window_size", "timepoints", None),
+        ("smooth_window", "Feature smoothing window", "spin_hmm_feature_smoothing_window", "timepoints", None),
+        ("lower_quantile_cap", "Low percentile cap", "spin_quant_lo", None, None),
+        ("upper_quantile_cap", "High percentile cap", "spin_quant_hi", None, None),
+        ("state_selection_mode", "State selection mode", "combo_hmm_n_states_mode", None, None),
+        ("number_of_states", "Number of states", "spin_hmm_n_states", None, mode == "fixed"),
+        ("minimum_states", "Minimum states", "spin_hmm_k_min", None, mode == "auto"),
+        ("maximum_states", "Maximum states", "spin_hmm_k_max", None, mode == "auto"),
+        ("start_offset", "Start offset", "spin_hmm_start_offset", "timepoints", None),
+        ("skipped_frames", "Skipped frames", "combo_hmm_start_offset_fill_mode", None, None),
+        ("covariance_type", "Covariance type", "combo_hmm_covariance_type", None, None),
+        ("maximum_iterations", "Maximum iterations", "spin_hmm_n_iter", None, None),
+        ("convergence_tolerance", "Convergence tolerance", "spin_hmm_tol", None, None),
+        ("minimum_covariance", "Minimum covariance", "spin_hmm_min_covar", None, None),
+        ("sticky.enabled", "Use sticky HMM", "chk_hmm_sticky", None, None),
+        ("sticky.kappa", "Stickiness kappa", "spin_hmm_stickiness_kappa", None, sticky),
+        ("sticky.transition_alpha", "Transition matrix alpha", "spin_hmm_transmat_alpha", None, sticky),
+        ("random_seed", "Random seed", "spin_seed", None, None),
+    ]
+    for suffix, label, attr, unit, visible in specs:
+        widget = getattr(state, attr, None)
+        if widget is not None:
+            out.append(_binding(f"analysis.state_classification.{cell_type or 'selected'}.{suffix}",
+                                f"{cell_type or 'Selected cell type'}: {label}", widget,
+                                step="analysis", method="HMM", cell_type=cell_type,
+                                unit=unit, visible=visible, persist=persist))
+    window_checks = {
+        "net_displacement": getattr(state, "chk_net_disp", None),
+        "straightness": getattr(state, "chk_straight", None),
+        "mean_square_displacement": getattr(state, "chk_msd", None),
+    }
+    window_checks = {key: widget for key, widget in window_checks.items()
+                     if widget is not None}
+    for suffix, label, checks in [
+        ("timepoint_features", "Timepoint features", getattr(state, "_timepoint_checkboxes", {})),
+        ("log_scaled_features", "Log-scaled features", getattr(state, "_logscale_checkboxes", {})),
+        ("binary_feature_groups", "Binary feature groups", getattr(state, "_bingrp_checkboxes", {})),
+        ("window_features", "Additional window features", window_checks),
+    ]:
+        if checks:
+            out.append(_checkset_binding(
+                f"analysis.state_classification.{cell_type or 'selected'}.{suffix}",
+                f"{cell_type or 'Selected cell type'}: {label}", checks,
+                step="analysis", method="HMM", cell_type=cell_type,
+                persist=persist,
+            ))
+    return out
+
+
+def control_bindings(main_widget) -> list[dict]:
+    """Return every assistant-editable control currently instantiated in the UI."""
+    out = []
+    for builder in (_metadata_bindings, _segmentation_bindings, _tracking_bindings,
+                    _feature_bindings, _filter_bindings, _analysis_bindings):
+        out.extend(_safe(lambda b=builder: b(main_widget), []) or [])
+    return out
+
+
+def control_registry(main_widget) -> list[dict]:
+    """Return JSON-safe public records for the model context."""
+    return [{k: v for k, v in binding.items() if not k.startswith("_")}
+            for binding in control_bindings(main_widget)]
+
+
+def find_control(main_widget, control_id: str) -> dict | None:
+    return next((item for item in control_bindings(main_widget)
+                 if item["id"] == control_id), None)
+
+
+def active_cell_type(main_widget, step: str) -> str | None:
+    tab_attr = {
+        "tracking": "tracking_tab",
+        "feature_extraction": "feature_extraction_tab",
+        "filtering": "filtering_tab",
+    }.get(step)
+    if tab_attr:
+        tab = getattr(main_widget, tab_attr, None)
+        tabs = getattr(tab, "cell_tabs", None) if tab is not None else None
+        panel = _safe(tabs.currentWidget) if tabs is not None else None
+        return getattr(panel, "cell_type", None)
+    if step == "segmentation":
+        segmentation = getattr(main_widget, "segmentation_tab", None)
+        method_combo = getattr(segmentation, "method_combo", None)
+        method_index = _safe(method_combo.currentIndex, -1) if method_combo is not None else -1
+        page_attr = {0: "apoc_page", 1: "convpaint_page"}.get(method_index)
+        page = getattr(segmentation, page_attr, None) if page_attr else None
+        training = getattr(page, "_training_widget", None) if page is not None else None
+        tabs = getattr(training, "tab_widget", None) if training is not None else None
+        index = _safe(tabs.currentIndex, -1) if tabs is not None else -1
+        cell_types = getattr(training, "_tab_cell_types", []) or []
+        if 0 <= index < len(cell_types):
+            return str(cell_types[index])
+        # The random-forest page has one vertical panel per type rather than an
+        # active sub-tab; return the only type when the choice is unambiguous.
+        if method_index == 2:
+            random_forest = getattr(segmentation, "pixel_classifier_page", None)
+            available = list((getattr(random_forest, "param_widgets", {}) or {}).keys())
+            if len(available) == 1:
+                return str(available[0])
+        return None
+    if step == "analysis":
+        analysis = getattr(main_widget, "analysis_tab", None)
+        single = getattr(analysis, "single_cell_tab", None) if analysis is not None else None
+        return _safe(single.cell_type_combo.currentText) if single is not None else None
+    return None

--- a/behav3d/napari/_assistant_recommendations.py
+++ b/behav3d/napari/_assistant_recommendations.py
@@ -1,0 +1,138 @@
+"""Deterministic calculations used by the BEHAV3D assistant."""
+from __future__ import annotations
+
+import math
+from statistics import median
+from typing import Any
+
+
+EDT_DIAMETER_FRACTIONS = (0.20, 0.25, 0.30)
+
+
+def _distance_um(value: Any, unit: Any) -> float:
+    from behav3d.core.utils import convert_distance
+
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise ValueError("Pixel size must be greater than zero.")
+    normalized_unit = str(unit or "um").strip() or "um"
+    if normalized_unit in {"um", "μm", "µm"}:
+        normalized_unit = "um"
+    return float(convert_distance(number, normalized_unit))
+
+
+def _half_pixel(value: float) -> float:
+    return max(0.5, round(float(value) * 2.0) / 2.0)
+
+
+def calculate_edt_recommendations(
+    records: list[dict],
+    *,
+    cell_diameter_um: float = 10.0,
+    organoid_cells_across: float | None = None,
+) -> dict:
+    """Convert metadata resolution into transparent EDT starting values.
+
+    EDT in the current segmentation implementation is measured in voxel/pixel
+    units. Candidate thresholds are 20%, 25%, and 30% of the expected XY object
+    diameter. These are starting points for previewing, not fitted parameters.
+
+    ``organoid_cells_across`` means the approximate number of 10-um cell widths
+    spanning the organoid diameter. This direct geometric input avoids pretending
+    that a total cell count uniquely determines organoid diameter.
+    """
+    diameter_um = float(cell_diameter_um)
+    if not math.isfinite(diameter_um) or diameter_um <= 0:
+        raise ValueError("Cell diameter must be greater than zero.")
+    if organoid_cells_across is not None:
+        cells_across = float(organoid_cells_across)
+        if not math.isfinite(cells_across) or cells_across < 1:
+            raise ValueError("Organoid size must be at least one cell width.")
+        object_diameter_um = diameter_um * cells_across
+    else:
+        cells_across = None
+        object_diameter_um = diameter_um
+
+    rows = []
+    skipped = []
+    for index, record in enumerate(records or []):
+        sample = str(record.get("sample_name") or f"Sample {index + 1}")
+        try:
+            xy_um = _distance_um(
+                record.get("pixel_distance_xy"), record.get("distance_unit", "um")
+            )
+        except (AssertionError, TypeError, ValueError) as exc:
+            skipped.append({"sample_name": sample, "reason": str(exc)})
+            continue
+        diameter_px = object_diameter_um / xy_um
+        candidates = [_half_pixel(diameter_px * fraction)
+                      for fraction in EDT_DIAMETER_FRACTIONS]
+        candidates = list(dict.fromkeys(candidates))
+        rows.append({
+            "sample_name": sample,
+            "pixel_size_xy_um": xy_um,
+            "object_diameter_um": object_diameter_um,
+            "object_diameter_px": diameter_px,
+            "object_radius_px": diameter_px / 2.0,
+            "edt_candidates_px": candidates,
+            "edt_start_px": _half_pixel(diameter_px * 0.25),
+        })
+
+    if not rows:
+        raise ValueError("No sample has a valid XY pixel size in the metadata.")
+
+    return {
+        "cell_diameter_um": diameter_um,
+        "organoid_cells_across": cells_across,
+        "object_diameter_um": object_diameter_um,
+        "rows": rows,
+        "skipped": skipped,
+        "global_start_px": _half_pixel(median(row["edt_start_px"] for row in rows)),
+        "fractions": list(EDT_DIAMETER_FRACTIONS),
+    }
+
+
+def format_edt_recommendations(result: dict, cell_type: str) -> str:
+    rows = result["rows"]
+    object_um = result["object_diameter_um"]
+    cells_across = result.get("organoid_cells_across")
+    assumption = f"a {object_um:g} µm object diameter"
+    if cells_across is not None:
+        assumption += (
+            f" ({cells_across:g} cell widths across, using "
+            f"{result['cell_diameter_um']:g} µm per cell)"
+        )
+
+    lines = [
+        f"**EDT starting points for {cell_type}**",
+        "",
+        f"Assumption: {assumption}.",
+        "",
+        "| Sample | XY resolution (µm/pixel) | Diameter (pixels) | EDT values to try |",
+        "|---|---:|---:|---:|",
+    ]
+    for row in rows:
+        trials = ", ".join(f"{value:g}" for value in row["edt_candidates_px"])
+        lines.append(
+            f"| {row['sample_name']} | {row['pixel_size_xy_um']:.4g} | "
+            f"{row['object_diameter_px']:.2f} | {trials} |"
+        )
+    lines.extend([
+        "",
+        f"A practical global starting value is **{result['global_start_px']:g} pixels** "
+        "(the median middle candidate across samples). Lower EDT values split touching "
+        "objects more aggressively; higher values keep more objects merged.",
+        "",
+        "These candidates are 20%, 25%, and 30% of the expected XY diameter. "
+        "They are XY-based starting points, so preview segmentation around them before "
+        "running the batch.",
+    ])
+    if any(max(row["edt_candidates_px"]) > 50 for row in rows):
+        lines.append(
+            "Some candidates exceed the current EDT control maximum of 50 pixels; "
+            "review the object-size assumption before applying them."
+        )
+    if result.get("skipped"):
+        samples = ", ".join(item["sample_name"] for item in result["skipped"])
+        lines.append(f"Skipped samples with invalid resolution metadata: {samples}.")
+    return "\n".join(lines)

--- a/behav3d/napari/_assistant_schema.py
+++ b/behav3d/napari/_assistant_schema.py
@@ -107,13 +107,14 @@ _DESCRIPTIONS: dict[str, str] = {
     # tracking — btrack
     "config_preset": "btrack motion-model preset: 'cell' (typical migrating cells) or 'particle' (fast, near-random motion).",
     "config_path": "Optional path to a custom btrack config JSON; overrides the preset.",
-    "max_search_radius": "btrack maximum linking radius in pixels.",
+    "use_visual_features": "Use image-derived intensity measurements alongside motion for btrack linking. This is separate from global track optimization.",
+    "max_search_radius": "btrack maximum linking radius in physical distance units (normally micrometres after metadata scaling).",
     "update_method": "btrack hypothesis update: 'EXACT' (accurate, slower) or 'APPROXIMATE' (faster for large datasets).",
     "step_size": "btrack optimiser batch/step size; larger trades memory for speed.",
     "n_workers": "Parallel workers for this step.",
     "use_optimize": "Run btrack's global optimisation pass (better tracks, slower).",
     "hypotheses": "btrack hypotheses to evaluate (P_FP false-positive, P_init initialisation, P_term termination, P_link linking, P_branch division).",
-    "dist_thresh": "btrack distance threshold (pixels) for candidate links.",
+    "dist_thresh": "btrack optimizer distance threshold in physical distance units (normally micrometres after metadata scaling).",
     "time_thresh": "btrack time threshold (frames) for candidate links.",
     # features
     "features_choice": "Which feature groups to compute for this cell category: movement, intensity, contact, death, morphology.",

--- a/behav3d/napari/_results_catalog.py
+++ b/behav3d/napari/_results_catalog.py
@@ -48,6 +48,16 @@ FILE_CATALOG: list[tuple[str, str]] = [
         "Bar plots of track counts after each filtering step (per sample).",
     ),
     (
+        "BEHAV3D_*_track_count_summary.csv",
+        "Standard per-sample cell-count comparison at timepoint 0 for minimum "
+        "track lengths of 20, 50, 100, and 200.",
+    ),
+    (
+        "BEHAV3D_*_track_count_query_t*_min_*.csv",
+        "Per-sample cell counts at one timepoint before and after minimum "
+        "track-length thresholds.",
+    ),
+    (
         "BEHAV3D_*_touching_distribution.pdf",
         "Distribution of contacts between tracks and the given target cell"
         " type, used to tune contact thresholds.",
@@ -327,11 +337,6 @@ def _classify(path: Path, analysis_root: Path) -> tuple[str, Optional[str], Opti
     parts = rel.parts
     cell_type = parts[0] if parts else None
 
-    if "quality_control" in parts:
-        return ("filtering", None, cell_type)
-    if "track_features" in parts:
-        return ("feature_extraction", None, cell_type)
-
     in_sc_dir = any(p in _SINGLE_CELL_DIRS for p in parts)
     name = path.name
     matches_sc_name = any(
@@ -339,6 +344,11 @@ def _classify(path: Path, analysis_root: Path) -> tuple[str, Optional[str], Opti
     )
     if in_sc_dir or matches_sc_name:
         return ("analysis", "single_cell", cell_type)
+
+    if "quality_control" in parts:
+        return ("filtering", None, cell_type)
+    if "track_features" in parts:
+        return ("feature_extraction", None, cell_type)
 
     return ("analysis", "death_dynamics", cell_type)
 

--- a/behav3d/napari/_tracking.py
+++ b/behav3d/napari/_tracking.py
@@ -723,10 +723,10 @@ class CellTypeTrackingPanel(QWidget):
         self.bt_max_search_radius.setRange(1, 9999)
         self.bt_max_search_radius.setValue(int(bt_cfg.get("max_search_radius", 100)))
         self.bt_max_search_radius.setMaximumWidth(80)
-        step1_form.addRow("Max search radius (px):", make_help_row(
+        step1_form.addRow("Max search radius (µm):", make_help_row(
             self.bt_max_search_radius,
-            "Max Search Radius (pixels)",
-            "Maximum isotropic distance (pixels) to search for\n"
+            "Max Search Radius (µm)",
+            "Maximum physical distance (µm) to search for\n"
             "linking objects between frames.\n\n"
             "Increase for fast-moving cells; decrease to\n"
             "prevent long-range false links."
@@ -843,10 +843,10 @@ class CellTypeTrackingPanel(QWidget):
         self.bt_dist_thresh.setRange(1, 9999)
         self.bt_dist_thresh.setValue(int(bt_cfg.get("dist_thresh", 60)))
         self.bt_dist_thresh.setMaximumWidth(80)
-        step2_form.addRow("Distance threshold:", make_help_row(
+        step2_form.addRow("Distance threshold (µm):", make_help_row(
             self.bt_dist_thresh,
-            "Distance Threshold",
-            "Maximum distance (pixels) for generating\n"
+            "Distance Threshold (µm)",
+            "Maximum physical distance (µm) for generating\n"
             "link/branch hypotheses in the optimizer."
         ))
 

--- a/behav3d/widgets/utils.py
+++ b/behav3d/widgets/utils.py
@@ -103,6 +103,7 @@ _DEFAULT_CONFIG = {
             "btrack": {
                 "config_preset": "cell",
                 "config_path": "",
+                "use_visual_features": False,
                 "max_search_radius": 100,
                 "update_method": "EXACT",
                 "step_size": 100,
@@ -132,6 +133,7 @@ _DEFAULT_CONFIG = {
             "btrack": {
                 "config_preset": "cell",
                 "config_path": "",
+                "use_visual_features": False,
                 "max_search_radius": 100,
                 "update_method": "EXACT",
                 "step_size": 100,
@@ -161,6 +163,7 @@ _DEFAULT_CONFIG = {
             "btrack": {
                 "config_preset": "cell",
                 "config_path": "",
+                "use_visual_features": False,
                 "max_search_radius": 100,
                 "update_method": "EXACT",
                 "step_size": 100,

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -17,9 +17,9 @@ Endpoints (FastAPI, public):
         {"type":"tool_calls","calls":[...]}  proposed actions (client confirms)
         {"type":"done"} | {"type":"error","message":...}
 
-Tool calls use DeepSeek's native function-calling; `set_parameter.key` is
-constrained to the real BEHAV3D parameter keys (enum) so the model can't invent
-them. `parse_tool_calls` is retained only as a fallback for a call accidentally
+Tool calls use DeepSeek's native function-calling; `set_ui_value.control_id` is
+constrained to the live control registry so the model can't invent fields.
+`parse_tool_calls` is retained only as a fallback for a call accidentally
 embedded in the content text.
 
 The pure helpers (:func:`build_system_prompt`, :func:`to_openai_tools`,
@@ -37,334 +37,93 @@ import re
 # ===========================================================================
 # Pure logic (no Modal / network) — unit-testable
 # ===========================================================================
-_TOOLCALL_RE = re.compile(r"<TOOLCALL>\s*(\{.*?\})\s*</TOOLCALL>", re.DOTALL)
-
-_TOOL_NAMES = ("set_parameter", "navigate_to_step", "add_queue_step", "fill_metadata_builder",
-               "bulk_fill_metadata", "select_segmentation_method")
-
-
-_CATEGORY_LABELS = {
-    "immune": "immune cells",
-    "organoid": "organoids",
-    "other": "other cells",
-    "all_organoids": "all organoids",
-}
-
-_LEAF_LABELS = {
-    "metadata_csv": "metadata CSV",
-    "output_dir": "output directory",
-    "default_apply_all": "dimension order",
-    "examples_per_sample": "examples per sample",
-    "sample_specific_classifier": "sample-specific classifier",
-    "workers": "worker count",
-    "use_all_timepoints": "use all timepoints",
-    "tp_start": "first timepoint",
-    "tp_end": "last timepoint",
-    "number_of_channels": "number of channels",
-    "labels_mode": "channel-label setup",
-    "channel_labels": "channel labels",
-    "method": "method",
-    "overwrite": "overwrite existing outputs",
-    "search_range_px": "search range",
-    "memory_frames": "memory frames",
-    "track_cost_px": "frame-to-frame linking distance",
-    "gap_close_cost_px": "gap-closing distance",
-    "gap_close_max_frames": "maximum gap length",
-    "max_search_radius": "maximum search radius",
-    "features_choice": "feature groups",
-    "contact_threshold": "contact distance",
-    "n_workers": "worker count",
-    "dead_perc_threshold": "dead-pixel threshold",
-    "exp_duration": "experiment duration",
-    "min_track_length": "minimum track length",
-    "max_track_length": "maximum track length",
-    "umap_min_dist": "UMAP minimum distance",
-    "umap_n_neighbors": "UMAP neighbors",
-    "nr_of_clusters": "number of clusters",
-}
-
-
-def label_for_key(key) -> str:
-    """Small local copy of the client-side labeler; Modal only has JSON cards."""
-    if not key:
-        return "Parameter"
-    parts = str(key).split(".")
-    leaf = parts[-1]
-    label = _LEAF_LABELS.get(leaf, leaf.replace("_", " "))
-    category = next((p for p in parts if p in _CATEGORY_LABELS), None)
-    method = next((p for p in parts if p in {"lap", "trackpy", "btrack"}), None)
-    top = parts[0] if parts else ""
-    prefixes = []
-    if category:
-        prefixes.append(_CATEGORY_LABELS[category])
-    if method and leaf != "method":
-        prefixes.append({"lap": "LAP", "trackpy": "TrackPy", "btrack": "btrack"}[method])
-    elif top == "pixel_classifier":
-        prefixes.append("pixel classifier")
-    elif top == "cellpose":
-        prefixes.append("Cellpose")
-    elif top == "features":
-        prefixes.append("feature extraction")
-    elif top == "track_filtering":
-        prefixes.append("track filtering")
-    elif top == "analysis":
-        prefixes.append("analysis")
-    return ": ".join(prefixes + [label]) if prefixes else label.capitalize()
+_TOOL_NAMES = (
+    "set_ui_value", "navigate_to_step", "add_queue_step", "fill_metadata_builder",
+    "bulk_fill_metadata", "show_track_length_distribution", "create_cell_type_group",
+    "create_btrack_config_copy", "open_result", "recommend_edt",
+    "summarize_track_counts",
+)
+_TOOL_NAME_PATTERN = "|".join(re.escape(name) for name in _TOOL_NAMES)
 
 
 def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict]) -> str:
-    """Assemble the system prompt from persona + context + retrieved docs."""
-    parts = [
-        "You are the BEHAV3D co-pilot, embedded in a napari plugin for analysing "
-        "cell behaviour in 3D fluorescent imaging. Be concise and concrete. Ground "
-        "every recommendation in the BEHAV3D KNOWLEDGE below and the user's CONTEXT. "
-        "If you are unsure, ask one clarifying question about their data.\n\n"
-        "FORMATTING (responses render as markdown in a narrow side panel): lead "
-        "with a one-sentence answer; use short paragraphs separated by blank lines; "
-        "use bullet/numbered lists for any set of items or steps; bold key terms "
-        "and researcher-facing labels; use `code` only for literal values; avoid "
-        "dense walls of text.\n\n"
-        "USER-FACING LANGUAGE RULE: Internal names such as `n_samples`, "
-        "`metadata.loaded`, `tracking.immune.btrack.max_search_radius`, and tool "
-        "names are for tool calls only. In normal text, use visible labels such as "
-        "\"Number of samples\", \"metadata loaded\", and \"immune cells: maximum "
-        "search radius\". Do not mention Python variables, dotted keys, JSON, or "
-        "tool-call syntax unless the user explicitly asks for implementation details.\n\n"
-        "TOOLS — always call a tool instead of asking the user to click manually:\n"
-        "- `fill_metadata_builder`: guide through the Metadata Builder one field at a time. "
-        "  Use whenever the user asks to build metadata or be walked through setup.\n"
-        "- `bulk_fill_metadata`: fill the WHOLE Metadata Builder in one call. Use when the "
-        "  user gives many values at once, provides a list of image files, or says 'fill "
-        "  everything' — do not fill field-by-field in that case.\n"
-        "- `set_parameter`: propose a parameter change using a dotted key from "
-        "  PARAMETERS FOR THIS STEP. Do NOT use set_parameter for the segmentation Method "
-        "  selector — use select_segmentation_method instead.\n"
-        "- `select_segmentation_method`: set the global Method dropdown on the Segmentation "
-        "  tab (value = the visible label, e.g. 'APOC', 'ConvPaint', 'Pixel Classifier', "
-        "  'Cellpose', 'Import segmentation').\n"
-        "- `navigate_to_step`: switch the active tab. Use proactively when a "
-        "  prerequisite is missing (e.g. metadata not loaded → navigate to data_preparation).\n"
-        "- `add_queue_step`: add a processing step to the queue.\n\n"
-        "TOOL-CALL RULE (CRITICAL): When the user gives you a value during a guided flow, "
-        "you MUST emit the fill_metadata_builder or set_parameter tool call in THAT SAME "
-        "response — never acknowledge an answer in text only. "
-        "Pattern: user answers → you call the tool → you ask the next question. "
-        "If you skip the tool call, the UI will not update.\n\n"
-        "ONE-QUESTION RULE: Ask exactly ONE question per turn. After the tool call, "
-        "ask the NEXT question. Never bundle multiple questions.\n\n"
-        "PREREQ RULE: If the current step or the step the user is asking about has "
-        "a blocker, address ONLY that blocker first. Call navigate_to_step to the "
-        "required tab when the user is on the wrong tab and explain why.\n\n"
-        "The app may fill empty fields immediately and asks before overwriting "
-        "existing values. In text, say what you are filling or asking next.",
-    ]
+    """Build the current control-grounded assistant contract."""
+    session = context.get("assistant_session", {}) or {}
+    intent = session.get("intent") or "free_form"
+    controls = (context.get("ui_state", {}) or {}).get("controls", []) or []
+    metadata = context.get("metadata", {}) or {}
+    validation = metadata.get("validation", []) or []
+    guidance = retrieved or []
+    tool_names = [tool.get("name") for tool in tools or []]
 
-    step = context.get("current_step", "?")
-    md = context.get("metadata", {})
-    mb_ctx = context.get("metadata_builder", {}) or {}
-    csv_loaded = md.get("loaded", False)
-    assistant_session = context.get("assistant_session", {}) or {}
-    confirmed_keys = set(assistant_session.get("confirmed_parameter_keys", []) or [])
-    active_ct = context.get("active_cell_type_tab")
-    ct_line = f"\n- Active cell-type sub-tab: {active_ct}" if active_ct else ""
-    parts.append(
-        "## CONTEXT\n"
-        f"- Current step/tab: {context.get('current_tab_label', step)}\n"
-        f"- Output dir set: {context.get('output_dir_set')}\n"
-        f"- Metadata CSV loaded: {csv_loaded}\n"
-        f"- Samples in loaded CSV: {md.get('n_samples', 0) if csv_loaded else 0}\n"
-        f"- Samples being entered in Metadata Builder: {mb_ctx.get('n_samples', 0)}\n"
-        f"- Cell types: {md.get('cell_types', {})}\n"
-        f"- Non-default parameters: {context.get('parameters', {})}\n"
-        f"- Queue: {[s.get('type') for s in context.get('queue', [])]}"
-        + ct_line
+    rules = (
+        "You are the BEHAV3D Assistant for researchers analysing 3D fluorescence imaging. "
+        "Answer the user's actual question first, then add only context that helps them decide "
+        "or act. Use concise researcher-facing labels and never expose control IDs, variable "
+        "names, dotted configuration keys, JSON, or tool names in normal prose.\n\n"
+        "TRUST AND SCOPE\n"
+        "- The LIVE CONTEXT is authoritative. Read all loaded metadata records and current control "
+        "values before asking for information. Never ask for a value already present.\n"
+        "- Field names in LIVE CONTEXT are internal only. In every visible response say 'XY pixel "
+        "size' instead of pixel_distance_xy, 'timepoint' instead of position_t, and 'sample' "
+        "instead of sample_name. This remains mandatory when quoting or summarizing metadata.\n"
+        "- When metadata.record_source is metadata_builder_draft, those records are the current form "
+        "values and supersede the last saved DataFrame for this conversation. Do not repeat a resolved "
+        "validation issue. Make clear that draft changes still need to be saved.\n"
+        "- Separate informational, planning, execution, and troubleshooting requests. Missing "
+        "prerequisites block execution only; they do not block explanations or planning.\n"
+        "- Treat errors as evidence and offer hypotheses to check. Do not claim a cause without evidence.\n"
+        "- Ask at most one focused question when an answer is genuinely needed. Do not manufacture a "
+        "step-by-step interview for a simple question.\n\n"
+        "ACTIONS\n"
+        "- To edit a visible field, call set_ui_value with an exact id from LIVE CONTROLS. Never invent "
+        "an id. Same-value requests are complete: acknowledge briefly and move to the next relevant "
+        "decision without calling the tool again.\n"
+        "- Use only controls matching the selected method and exact cell type. Do not apply a change to "
+        "a broad cell category.\n"
+        "- Navigation and read-only result/preview actions may happen immediately. Filling a blank field "
+        "may happen immediately. Overwriting a populated value, creating a file/group, or adding queue "
+        "work requires user confirmation in the client.\n"
+        "- Never tell the user to click a field that you can edit with set_ui_value.\n"
+        "- Do not claim an action succeeded in prose. State the intended change briefly; the client "
+        "reports whether it was applied.\n"
+        "- For EDT advice, use recommend_edt so the conversion comes from metadata. Use a 10 um cell "
+        "diameter by default. For an organoid, first ask how many cell widths span its diameter. Treat "
+        "the returned values as preview starting points, not ground truth.\n"
+        "- For cell counts under minimum track-length filters or at a requested timepoint, always use "
+        "summarize_track_counts. Never estimate counts or calculate them from prose.\n"
+        "- Produce at most the actions needed for this one user turn. There is no hidden continuation turn."
     )
+    context_text = json.dumps({
+        "intent": intent,
+        "current_step": context.get("current_step"),
+        "current_tab_label": context.get("current_tab_label"),
+        "active_cell_type": context.get("active_cell_type"),
+        "output_dir_set": context.get("output_dir_set"),
+        "metadata": metadata,
+        "metadata_builder": context.get("metadata_builder"),
+        "segmentation": context.get("segmentation"),
+        "active_preview": context.get("active_preview"),
+        "step_readiness": context.get("step_readiness"),
+        "queue": context.get("queue", []),
+        "results": context.get("results", []),
+        "live_controls": controls,
+        "available_actions": tool_names,
+    }, indent=2, default=str)
+    knowledge = "\n\n".join(
+        f"[{item.get('id') or item.get('title', 'guidance')}] {item.get('text', '')}"
+        for item in guidance if item.get("text")
+    )
+    validation_note = (
+        "Metadata validation has no flagged items."
+        if not validation else
+        "Discuss validation items only when relevant; 'review' notes are not errors."
+    )
+    return (f"{rules}\n\nSESSION INTENT: {intent}\n{validation_note}\n\n"
+            f"LIVE CONTEXT\n{context_text}\n\n"
+            f"FEEDBACK-GROUNDED KNOWLEDGE\n{knowledge or 'No additional card selected.'}")
 
-    # Step readiness — show blockers so the model can redirect proactively.
-    readiness = context.get("step_readiness", {})
-    current_ready = readiness.get(step)
-    if current_ready is not None:
-        status = "ready" if current_ready.get("ready", True) else "not ready"
-        blockers = ", ".join(current_ready.get("blockers", [])) or "none"
-        parts.append(
-            "## CURRENT STEP READINESS\n"
-            f"- {step}: {status}; blockers: {blockers}"
-        )
-    downstream = {
-        k: v for k, v in readiness.items()
-        if k != step and not v.get("ready", True)
-    }
-    if downstream:
-        lines = [
-            f"- {k}: {', '.join(v.get('blockers', ['unknown blocker']))}"
-            for k, v in downstream.items()
-        ]
-        parts.append(
-            "## DOWNSTREAM BLOCKERS\n"
-            "Use these only when the user asks about that later step:\n" + "\n".join(lines)
-        )
 
-    mb = context.get("metadata_builder", {})
-    if mb:
-        org = mb.get("organoid_names", [])
-        imm = mb.get("immune_names", [])
-        oth = mb.get("other_names", [])
-        sample_forms = mb.get("sample_forms", []) or []
-        sample_lines = []
-        for sample in sample_forms[:3]:
-            sample_lines.append(
-                f"- {sample.get('label', 'Sample')}: basic={sample.get('basic', {})}; "
-                f"cell_types={list((sample.get('cell_types') or {}).keys())}"
-            )
-        samples_text = "\n".join(sample_lines) if sample_lines else "- none"
-        parts.append(
-            "## METADATA BUILDER STATE\n"
-            f"- Builder open: {mb.get('open')}\n"
-            f"- n_samples={mb.get('n_samples')}, n_organoids={mb.get('n_organoids')}, "
-            f"n_immune={mb.get('n_immune')}, n_other={mb.get('n_other')}, "
-            f"include_dead={mb.get('include_dead')}\n"
-            f"- Cell types configured: {mb.get('cell_types_configured')} "
-            f"(organoids={org}, immune={imm}, other={oth})\n"
-            f"- Sample forms created: {mb.get('sample_forms_created')} "
-            f"(count={mb.get('sample_form_count', 0)})\n"
-            f"- Visible sample forms (first 3):\n{samples_text}\n\n"
-            "Use `fill_metadata_builder` tool calls to fill the form. "
-            "In user-facing text, use visible labels such as Number of samples, "
-            "Organoid types, Immune types, Image path, Pixel XY, Pixel Z, and "
-            "Time interval. "
-            "REQUIRED ORDER: open_builder → n_samples / n_organoids / n_immune / n_other / "
-            "include_dead → configure_cell_types → organoid_name / immune_name / other_name "
-            "(index 0, 1, …; use immune_multicolor and immune_multicolor_channels when needed) "
-            "→ create_sample_forms → per-sample fields (sample_name, exp_nr, well, "
-            "raw_image_path, pixel_distance_xy, pixel_distance_z, time_interval, time_unit, "
-            "dead_channel_number, dead_mask_path). "
-            "For per-sample cell-type rows, use cell_line, cell_condition, "
-            "cell_segments_image_path, cell_tracks_image_path, and cell_tracks_csv_path "
-            "with the exact visible cell_type name. "
-            "After filling Sample 1, call fill_down to copy shared values to all others. "
-            "Never skip configure_cell_types or create_sample_forms — they are required actions.\n"
-            "IMPORTANT: every value shown above is ALREADY FILLED IN — never ask the user "
-            "to provide it again. Only ask for fields that are still blank or at their default."
-        )
-
-    seg = context.get("segmentation", {}) or {}
-    if seg:
-        parts.append(
-            "## SEGMENTATION UI STATE\n"
-            f"- Current method: {seg.get('method')}\n"
-            f"- Available methods: {seg.get('available_methods', [])}\n"
-            "APOC (GPU), ConvPaint, Pixel Classifier (Random Forest), Cellpose, "
-            "and Import segmentation are distinct choices. If the user says APOC, "
-            "guide the APOC page; do not call it Pixel Classifier."
-        )
-
-    # Params still at default — surface the most actionable missing configs.
-    at_default = context.get("required_params_at_default", [])
-    if confirmed_keys:
-        at_default = [p for p in at_default if p.get("key") not in confirmed_keys]
-        parts.append(
-            "## CONFIRMED VALUES\n"
-            "The user has already accepted these current values; do not ask about "
-            "them again unless they ask to change them:\n"
-            + "\n".join(f"- {label_for_key(k)} [internal key: `{k}`]" for k in sorted(confirmed_keys))
-        )
-    if at_default:
-        lines = [
-            f"- {label_for_key(p['key'])} [internal key: `{p['key']}`] "
-            f"(default {p['default']!r}): {p.get('description', '')}"
-            for p in at_default[:6]
-        ]
-        parts.append(
-            "## PARAMS STILL AT DEFAULT\n"
-            "These parameters have not been changed from their defaults — ask about "
-            "the most important one if guiding the user:\n" + "\n".join(lines)
-        )
-
-    schema = context.get("step_schema", [])
-    if schema:
-        lines = [f"- {label_for_key(c['key'])} [internal key: `{c['key']}`] "
-                 f"(default {c['default']!r}"
-                 + (f", choices {c['choices']}" if c.get("choices") else "") + ")"
-                 for c in schema[:40]]
-        parts.append(
-            "## PARAMETERS FOR THIS STEP\n"
-            "Use the internal key only inside set_parameter calls. Use the label in text.\n"
-            + "\n".join(lines)
-        )
-
-    # Per-step guided flow instructions.
-    _step_guides = {
-        "data_preparation": (
-            "FIRST read the ## METADATA BUILDER STATE block above — it is the source of "
-            "truth for what is already filled in. NEVER re-ask for any value that already "
-            "appears there (a value that is already set counts as the user's answer — move "
-            "on).\n"
-            "Work through this decision order and address ONLY the first unsatisfied item, "
-            "then ask the next question:\n"
-            "1. If the output directory is not set, ask for the output directory path; on "
-            "answer, call set_parameter(key='paths.output_dir').\n"
-            "2. If the builder is not open, call fill_metadata_builder(open_builder).\n"
-            "3. For each of n_samples / n_organoids / n_immune / n_other still at its default "
-            "(1 / 0 / 0 / 0) and not yet given by the user: ask for it and call "
-            "fill_metadata_builder with the answer in the SAME turn. Skip any already above "
-            "its default.\n"
-            "4. Once the counts are set but 'Cell types configured' is False, call "
-            "fill_metadata_builder(configure_cell_types) (no user input needed).\n"
-            "5. For each cell-type name still blank, ask it and call "
-            "fill_metadata_builder(organoid_name / immune_name / other_name, index=i). Skip "
-            "names already present in organoids/immune/other.\n"
-            "6. Once names are set but 'Sample forms created' is False, call "
-            "fill_metadata_builder(create_sample_forms) (no user input needed).\n"
-            "7. For each sample, ask only for the per-sample fields that are still blank in "
-            "the 'Visible sample forms' snapshot (raw_image_path, pixel_distance_xy/z, "
-            "time_interval/time_unit, etc.) and fill them. Skip any already filled.\n"
-            "8. Ask for line/condition only when the metadata needs it; fill those with "
-            "cell_line/cell_condition and the visible cell_type name.\n"
-            "9. After Sample 1 is complete and there are multiple samples, call "
-            "fill_metadata_builder(fill_down) to copy shared values.\n"
-            "BULK SHORTCUT: if the user provides many values at once, gives a list of image "
-            "files, or says 'fill everything', call bulk_fill_metadata ONCE with all the "
-            "counts, names, and per-sample dicts instead of filling one field at a time.\n"
-            "CRITICAL: when the user gives you a value, emit the matching tool call in that "
-            "SAME turn — never acknowledge in text only."
-        ),
-        "segmentation": (
-            "Verify metadata is loaded and output_dir is set before anything else. "
-            "Ask about the global Method dropdown first. The visible choices are APOC (GPU), "
-            "ConvPaint (DL pixel classifier), Pixel Classifier (Random Forest), Cellpose "
-            "(Deep Learning), and Import segmentation. APOC is not the same thing as "
-            "Pixel Classifier (Random Forest). When the user picks a method, call "
-            "select_segmentation_method with the leading visible label ('APOC', 'ConvPaint', "
-            "'Pixel Classifier', 'Cellpose', or 'Import segmentation') — that switches the "
-            "visible parameter page — then guide that method's parameters. Once the user "
-            "accepts the current/default value for a setting, move to the next setting; "
-            "do not ask about it again. For Cellpose: ask number_of_channels, then "
-            "labels_mode. For Pixel Classifier: ask examples_per_sample, workers, "
-            "use_all_timepoints. For APOC or ConvPaint: guide the user through generating "
-            "training data, labeling, training, and then batch segmentation."
-        ),
-        "tracking": (
-            "Read cell types from context. For each immune type: default=btrack, state it and ask "
-            "to confirm, then ask max_search_radius. For organoid: default=propagation. "
-            "For other: default=lap. Propose set_parameter calls for method and key params, "
-            "one at a time. After each type is configured, move to the next."
-        ),
-        "feature_extraction": (
-            "Check metadata.columns for *_tracks_image_path — missing means tracking is not done. "
-            "Use features.<category>.contact_threshold for the contact distance (in µm). "
-            "Use features.<category>.n_workers for worker count. "
-            "Check metadata.columns for a dead_channel column to detect viability staining."
-        ),
-    }
-    guide = _step_guides.get(step)
-    if guide:
-        parts.append(f"## GUIDED FLOW — {step.upper()}\n{guide}")
-
-    if retrieved:
-        docs = "\n\n".join(f"[{d.get('title','doc')}] {d.get('text','')}" for d in retrieved)
-        parts.append("## BEHAV3D KNOWLEDGE (retrieved)\n" + docs)
-
-    return "\n\n".join(parts)
 
 
 def _balanced_json_spans(text: str):
@@ -407,7 +166,7 @@ def parse_tool_calls(text: str) -> tuple[str, list[dict]]:
 
     Accepts the canonical ``<TOOLCALL>{...}</TOOLCALL>`` as well as the common
     small-model variants: ``TOOLCALL>{...}`` (missing `<`/closing tag) and bare
-    ``set_parameter{...}`` where the object holds the arguments. Returns
+    ``set_ui_value{...}`` where the object holds the arguments. Returns
     (clean_text_for_display, calls)."""
     calls: list[dict] = []
     for start, _end, obj in _balanced_json_spans(text):
@@ -416,14 +175,13 @@ def parse_tool_calls(text: str) -> tuple[str, list[dict]]:
         name = obj.get("name")
         if name in _TOOL_NAMES:
             calls.append({"name": name, "arguments": obj.get("arguments", {}) or {}})
-        elif any(k in obj for k in ("key", "step", "step_type", "field")):
+        elif any(k in obj for k in ("control_id", "step", "step_type", "field",
+                                    "result_id", "cell_type", "group_name",
+                                    "position_t", "minimum_lengths",
+                                    "cell_diameter_um", "organoid_cells_across")):
             # bare arguments object — infer the tool from the preceding token
             pre = text[max(0, start - 48):start]
-            m = re.search(
-                r"(set_parameter|navigate_to_step|add_queue_step|fill_metadata_builder)"
-                r"[^A-Za-z0-9_]*$",
-                pre,
-            )
+            m = re.search(rf"({_TOOL_NAME_PATTERN})[^A-Za-z0-9_]*$", pre)
             if m:
                 calls.append({"name": m.group(1), "arguments": obj})
     return split_streamable(text), calls
@@ -432,12 +190,9 @@ def parse_tool_calls(text: str) -> tuple[str, list[dict]]:
 def split_streamable(text: str) -> str:
     """Return only the human-visible prefix — text before any tool-call syntax,
     whether well-formed (`<TOOLCALL>`), malformed (`TOOLCALL>`), or bare
-    (`set_parameter{`/`set_parameter(`)."""
+    (`set_ui_value{`/`set_ui_value(`)."""
     idxs = [text.find(mk) for mk in ("<TOOLCALL", "TOOLCALL>") if text.find(mk) != -1]
-    m = re.search(
-        r"(?:set_parameter|navigate_to_step|add_queue_step|fill_metadata_builder)\s*[\({]",
-        text,
-    )
+    m = re.search(rf"(?:{_TOOL_NAME_PATTERN})\s*[\x28\x7b]", text)
     if m:
         idxs.append(m.start())
     return text[:min(idxs)].rstrip() if idxs else text.rstrip()
@@ -448,14 +203,14 @@ _QUEUE_STEP_TYPES = ["segment", "train", "track", "feature_extract", "filter", "
 
 def to_openai_tools(tool_schema: list[dict], key_enum=None) -> list[dict]:
     """Wrap our TOOL_SCHEMA (name/description/parameters) into OpenAI `tools`
-    format. If `key_enum` is given, constrain `set_parameter.key` to those values
-    so the model cannot invent parameter keys."""
+    format. If `key_enum` is given, constrain `set_ui_value.control_id` to those
+    live values so the model cannot invent fields."""
     out = []
     for t in tool_schema or []:
         params = json.loads(json.dumps(t.get("parameters", {})))  # deep copy
-        if t.get("name") == "set_parameter" and key_enum:
+        if t.get("name") == "set_ui_value" and key_enum:
             props = params.setdefault("properties", {})
-            key_prop = props.setdefault("key", {"type": "string"})
+            key_prop = props.setdefault("control_id", {"type": "string"})
             key_prop["enum"] = list(key_enum)
         if t.get("name") == "add_queue_step":
             props = params.setdefault("properties", {})
@@ -547,6 +302,7 @@ if modal is not None:
         )
         .add_local_file("chatbot/embeddings.py", "/root/embeddings.py")
         .add_local_file("chatbot/ingest.py", "/root/ingest.py")
+        .add_local_file("chatbot/guidance.py", "/root/guidance.py")
         .add_local_file("chatbot/schema_cards.json", "/root/schema_cards.json")
     )
     # Knowledge sources — paths are relative to CWD, so run modal from the repo root.
@@ -597,13 +353,7 @@ if modal is not None:
             index = VectorIndex.load(INDEX_DIR)
         except Exception:
             index = VectorIndex()
-        # Valid parameter keys → constrain set_parameter so the model can't invent.
-        try:
-            with open("/root/schema_cards.json", encoding="utf-8") as f:
-                _key_enum = [c["key"] for c in json.load(f)
-                             if not c["key"].startswith("calculated_features.")]
-        except Exception:
-            _key_enum = []
+        from guidance import KNOWLEDGE_VERSION, select_guidance_cards
 
         # deepseek-v4-flash is the explicit V4 Flash id (tool-calls + streaming).
         # The older `deepseek-chat` alias also maps to it but is being deprecated.
@@ -614,7 +364,9 @@ if modal is not None:
 
         @api.get("/health")
         def health():
-            return {"ok": True, "chunks": len(index.chunks), "model": deepseek_model}
+            return {"ok": True, "chunks": len(index.chunks), "model": deepseek_model,
+                    "control_contract_version": "2.0",
+                    "knowledge_version": KNOWLEDGE_VERSION}
 
         @api.post("/chat")
         async def chat(request: Request):
@@ -631,10 +383,17 @@ if modal is not None:
             except Exception:
                 retrieved = []
 
+            intent = (context.get("assistant_session", {}) or {}).get("intent")
+            deterministic = select_guidance_cards(context, user_msg, intent)
+            retrieved = deterministic + retrieved
+
             system = build_system_prompt(context, retrieved, tools)
             convo = [{"role": "system", "content": system}]
             convo += [m for m in messages if m.get("role") != "system"]
-            oai_tools = to_openai_tools(tools, key_enum=_key_enum)
+            control_ids = [item.get("id") for item in
+                           (context.get("ui_state", {}) or {}).get("controls", [])
+                           if item.get("id") and item.get("enabled") and item.get("visible")]
+            oai_tools = to_openai_tools(tools, key_enum=control_ids)
 
             def sse(obj):
                 return "data: " + json.dumps(obj) + "\n\n"

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -1,0 +1,83 @@
+"""Versioned, feedback-grounded guidance for the BEHAV3D assistant."""
+from __future__ import annotations
+
+
+KNOWLEDGE_VERSION = "2026.07.14.2"
+
+
+GUIDANCE_CARDS = {
+    "metadata": (
+        "Loaded metadata is authoritative. Read every record and validation note before asking "
+        "for a value. Never ask the user to repeat a value that is present. A folder of TIFFs is "
+        "not one supported movie input: each sample needs one multidimensional image file or "
+        "hyperstack. Valid 5D dimension orders are TCZYX, TZCYX, ZCTYX, ZTCYX, CZTYX, and CTZYX. "
+        "When asked what analysis to run, first ask the research question; do not infer it from "
+        "metadata alone."
+    ),
+    "segmentation": (
+        "Method ladder: start with APOC for a fast GPU-assisted interactive baseline. Use ConvPaint "
+        "for more complex appearance when extra training and compute are acceptable. Use Pixel "
+        "Classifier (Random Forest) when no suitable GPU is available. Use a custom-trained Cellpose "
+        "model when repeatable accuracy across experiments justifies model training. Import accepts "
+        "existing TIFF or zarr segmentations. After a method is selected, discuss only controls whose "
+        "method matches that selection. APOC is not the Random Forest pixel classifier. For EDT advice, "
+        "calculate the expected XY diameter from each sample's pixel_distance_xy. A 10 um cell is the "
+        "default reference. Try 20%, 25%, and 30% of the diameter in pixels as transparent preview "
+        "starting points. For organoids, first ask how many cell widths span the diameter."
+    ),
+    "tracking": (
+        "Read the current values for the exact cell type before recommending changes. btrack maximum "
+        "search radius and optimizer distance threshold are physical distances after metadata scaling, "
+        "normally micrometres, not pixels. Use visual features adds image-derived measurements to "
+        "linking; global optimization is a separate second stage. Discuss P_branch only when global "
+        "optimization is already enabled and divisions matter. For customization, copy the bundled "
+        "cell_config.json and edit the copy. Describe tracking failures as hypotheses to check, not "
+        "certain diagnoses."
+    ),
+    "feature_extraction": (
+        "Cell-type grouping is available in Feature Extraction and creates a merged metadata type; "
+        "existing tracks do not need to be recomputed. In the dead-threshold preview, green means alive "
+        "and red means dead; hovering shows the dead-mask percentage. If the preview is ambiguous, ask "
+        "what looks wrong before recommending a threshold."
+    ),
+    "filtering": (
+        "Use the track-length distribution preview before choosing a minimum length. A higher minimum "
+        "removes short unreliable tracks but can exclude real short-lived behavior. Visual accuracy and "
+        "the downstream analysis matter more than forcing equal track lengths. Trim to equal lengths only "
+        "when the selected downstream workflow requires comparable windows. For count questions, use "
+        "the unfiltered combined track-features CSV. Track length is the number of unique position_t "
+        "values per sample and TrackID. Count only qualifying tracks that are present at the requested "
+        "position_t; never estimate the result."
+    ),
+    "analysis": (
+        "State Classification uses an HMM on per-timepoint and rolling-window features. Track "
+        "Classification contains whole-trajectory clustering, including legacy DTW; do not conflate them. "
+        "Begin with a small set of biologically interpretable features. Treat 3D morphology cautiously "
+        "when Z sampling is coarse. Window size controls rolling feature calculation; Smooth window "
+        "controls feature smoothing. All continuous features are standardized; log1p is optional for "
+        "strongly right-skewed non-negative features. HMM diagnostics and the state-feature heatmap are in "
+        "analysis/<cell_type>/behavioral_states/processing/hmm_behavioral_classification/quality_control/"
+        "raw/behavioral_clustering_diagnostics.pdf."
+    ),
+}
+
+
+def select_guidance_cards(context: dict, user_message: str = "", intent: str | None = None) -> list[dict]:
+    """Select deterministic cards before generic vector retrieval."""
+    step = str(context.get("current_step") or "")
+    query = f"{user_message} {intent or ''}".lower()
+    selected: list[str] = []
+    if step in GUIDANCE_CARDS:
+        selected.append(step)
+    keyword_map = {
+        "metadata": ("metadata", "sample", "dimension", "image path", "tiff", "voxel"),
+        "segmentation": ("segment", "apoc", "convpaint", "cellpose", "random forest", "edt"),
+        "tracking": ("track", "btrack", "branch", "visual feature", "search radius"),
+        "feature_extraction": ("feature", "group", "death", "dead threshold", "preview"),
+        "filtering": ("filter", "track length", "short track", "distribution", "cell count", "timepoint"),
+        "analysis": ("analysis", "hmm", "dtw", "state", "cluster", "log", "heatmap"),
+    }
+    for key, words in keyword_map.items():
+        if key not in selected and any(word in query for word in words):
+            selected.append(key)
+    return [{"id": key, "text": GUIDANCE_CARDS[key]} for key in selected]

--- a/chatbot/schema_cards.json
+++ b/chatbot/schema_cards.json
@@ -518,6 +518,16 @@
     "description": "Optional path to a custom btrack config JSON; overrides the preset."
   },
   {
+    "key": "tracking.immune.btrack.use_visual_features",
+    "title": "use_visual_features",
+    "step": "tracking",
+    "category": "immune",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Use image-derived intensity measurements alongside motion for btrack linking. This is separate from global track optimization."
+  },
+  {
     "key": "tracking.immune.btrack.max_search_radius",
     "title": "max_search_radius",
     "step": "tracking",
@@ -525,7 +535,7 @@
     "type": "int",
     "default": 100,
     "choices": null,
-    "description": "btrack maximum linking radius in pixels."
+    "description": "btrack maximum linking radius in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.immune.btrack.update_method",
@@ -593,7 +603,7 @@
     "type": "int",
     "default": 60,
     "choices": null,
-    "description": "btrack distance threshold (pixels) for candidate links."
+    "description": "btrack optimizer distance threshold in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.immune.btrack.time_thresh",
@@ -745,6 +755,16 @@
     "description": "Optional path to a custom btrack config JSON; overrides the preset."
   },
   {
+    "key": "tracking.other.btrack.use_visual_features",
+    "title": "use_visual_features",
+    "step": "tracking",
+    "category": "other",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Use image-derived intensity measurements alongside motion for btrack linking. This is separate from global track optimization."
+  },
+  {
     "key": "tracking.other.btrack.max_search_radius",
     "title": "max_search_radius",
     "step": "tracking",
@@ -752,7 +772,7 @@
     "type": "int",
     "default": 100,
     "choices": null,
-    "description": "btrack maximum linking radius in pixels."
+    "description": "btrack maximum linking radius in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.other.btrack.update_method",
@@ -820,7 +840,7 @@
     "type": "int",
     "default": 60,
     "choices": null,
-    "description": "btrack distance threshold (pixels) for candidate links."
+    "description": "btrack optimizer distance threshold in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.other.btrack.time_thresh",
@@ -972,6 +992,16 @@
     "description": "Optional path to a custom btrack config JSON; overrides the preset."
   },
   {
+    "key": "tracking.organoid.btrack.use_visual_features",
+    "title": "use_visual_features",
+    "step": "tracking",
+    "category": "organoid",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Use image-derived intensity measurements alongside motion for btrack linking. This is separate from global track optimization."
+  },
+  {
     "key": "tracking.organoid.btrack.max_search_radius",
     "title": "max_search_radius",
     "step": "tracking",
@@ -979,7 +1009,7 @@
     "type": "int",
     "default": 100,
     "choices": null,
-    "description": "btrack maximum linking radius in pixels."
+    "description": "btrack maximum linking radius in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.organoid.btrack.update_method",
@@ -1047,7 +1077,7 @@
     "type": "int",
     "default": 60,
     "choices": null,
-    "description": "btrack distance threshold (pixels) for candidate links."
+    "description": "btrack optimizer distance threshold in physical distance units (normally micrometres after metadata scaling)."
   },
   {
     "key": "tracking.organoid.btrack.time_thresh",
@@ -1476,6 +1506,66 @@
     "description": "Number of behavioural clusters to extract."
   },
   {
+    "key": "analysis.immune.feature_scaling_preset",
+    "title": "feature_scaling_preset",
+    "step": "analysis",
+    "category": "immune",
+    "type": "none",
+    "default": null,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.immune.feature_scaling_preset' (type none, default None)."
+  },
+  {
+    "key": "analysis.immune.min_track_length_enabled",
+    "title": "min_track_length_enabled",
+    "step": "analysis",
+    "category": "immune",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the minimum-track-length filter is active."
+  },
+  {
+    "key": "analysis.immune.min_track_length",
+    "title": "min_track_length",
+    "step": "analysis",
+    "category": "immune",
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "Discard tracks shorter than this many frames."
+  },
+  {
+    "key": "analysis.immune.max_track_length_enabled",
+    "title": "max_track_length_enabled",
+    "step": "analysis",
+    "category": "immune",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the maximum-track-length filter is active."
+  },
+  {
+    "key": "analysis.immune.max_track_length",
+    "title": "max_track_length",
+    "step": "analysis",
+    "category": "immune",
+    "type": "int",
+    "default": 999999,
+    "choices": null,
+    "description": "Discard tracks longer than this many frames."
+  },
+  {
+    "key": "analysis.immune.feature_dtw_napari_backprojection_workers",
+    "title": "feature_dtw_napari_backprojection_workers",
+    "step": "analysis",
+    "category": "immune",
+    "type": "int",
+    "default": 4,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.immune.feature_dtw_napari_backprojection_workers' (type int, default 4)."
+  },
+  {
     "key": "analysis.immune.dtw_feature_groups_enabled.morphology",
     "title": "morphology",
     "step": "analysis",
@@ -1596,6 +1686,66 @@
     "description": "Number of behavioural clusters to extract."
   },
   {
+    "key": "analysis.organoid.feature_scaling_preset",
+    "title": "feature_scaling_preset",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "none",
+    "default": null,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.organoid.feature_scaling_preset' (type none, default None)."
+  },
+  {
+    "key": "analysis.organoid.min_track_length_enabled",
+    "title": "min_track_length_enabled",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the minimum-track-length filter is active."
+  },
+  {
+    "key": "analysis.organoid.min_track_length",
+    "title": "min_track_length",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "Discard tracks shorter than this many frames."
+  },
+  {
+    "key": "analysis.organoid.max_track_length_enabled",
+    "title": "max_track_length_enabled",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the maximum-track-length filter is active."
+  },
+  {
+    "key": "analysis.organoid.max_track_length",
+    "title": "max_track_length",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "int",
+    "default": 999999,
+    "choices": null,
+    "description": "Discard tracks longer than this many frames."
+  },
+  {
+    "key": "analysis.organoid.feature_dtw_napari_backprojection_workers",
+    "title": "feature_dtw_napari_backprojection_workers",
+    "step": "analysis",
+    "category": "organoid",
+    "type": "int",
+    "default": 4,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.organoid.feature_dtw_napari_backprojection_workers' (type int, default 4)."
+  },
+  {
     "key": "analysis.organoid.dtw_feature_groups_enabled.morphology",
     "title": "morphology",
     "step": "analysis",
@@ -1714,6 +1864,66 @@
     "default": 5,
     "choices": null,
     "description": "Number of behavioural clusters to extract."
+  },
+  {
+    "key": "analysis.other.feature_scaling_preset",
+    "title": "feature_scaling_preset",
+    "step": "analysis",
+    "category": "other",
+    "type": "none",
+    "default": null,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.other.feature_scaling_preset' (type none, default None)."
+  },
+  {
+    "key": "analysis.other.min_track_length_enabled",
+    "title": "min_track_length_enabled",
+    "step": "analysis",
+    "category": "other",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the minimum-track-length filter is active."
+  },
+  {
+    "key": "analysis.other.min_track_length",
+    "title": "min_track_length",
+    "step": "analysis",
+    "category": "other",
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "Discard tracks shorter than this many frames."
+  },
+  {
+    "key": "analysis.other.max_track_length_enabled",
+    "title": "max_track_length_enabled",
+    "step": "analysis",
+    "category": "other",
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "Whether the maximum-track-length filter is active."
+  },
+  {
+    "key": "analysis.other.max_track_length",
+    "title": "max_track_length",
+    "step": "analysis",
+    "category": "other",
+    "type": "int",
+    "default": 999999,
+    "choices": null,
+    "description": "Discard tracks longer than this many frames."
+  },
+  {
+    "key": "analysis.other.feature_dtw_napari_backprojection_workers",
+    "title": "feature_dtw_napari_backprojection_workers",
+    "step": "analysis",
+    "category": "other",
+    "type": "int",
+    "default": 4,
+    "choices": null,
+    "description": "BEHAV3D parameter 'analysis.other.feature_dtw_napari_backprojection_workers' (type int, default 4)."
   },
   {
     "key": "analysis.other.dtw_feature_groups_enabled.morphology",
@@ -2004,6 +2214,532 @@
     "description": "Fraction of dead-mask pixels above which a cell is considered dead."
   },
   {
+    "key": "behavioral_state_classification.defaults.hmm_n_states_mode",
+    "title": "hmm_n_states_mode",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "fixed",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_n_states_mode' (type str, default 'fixed')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_n_states",
+    "title": "hmm_n_states",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 4,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_n_states' (type int, default 4)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_k_min",
+    "title": "hmm_k_min",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 2,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_k_min' (type int, default 2)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_k_max",
+    "title": "hmm_k_max",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 8,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_k_max' (type int, default 8)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_covariance_type",
+    "title": "hmm_covariance_type",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "full",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_covariance_type' (type str, default 'full')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_n_iter",
+    "title": "hmm_n_iter",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 500,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_n_iter' (type int, default 500)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_tol",
+    "title": "hmm_tol",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "float",
+    "default": 0.001,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_tol' (type float, default 0.001)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_sticky",
+    "title": "hmm_sticky",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_sticky' (type bool, default False)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_stickiness_kappa",
+    "title": "hmm_stickiness_kappa",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "float",
+    "default": 8.0,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_stickiness_kappa' (type float, default 8.0)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_transmat_alpha",
+    "title": "hmm_transmat_alpha",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "float",
+    "default": 1.0,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_transmat_alpha' (type float, default 1.0)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_min_covar",
+    "title": "hmm_min_covar",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "float",
+    "default": 0.001,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_min_covar' (type float, default 0.001)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_feature_smoothing_window",
+    "title": "hmm_feature_smoothing_window",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 5,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_feature_smoothing_window' (type int, default 5)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_smoothing_min_periods",
+    "title": "hmm_smoothing_min_periods",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_smoothing_min_periods' (type int, default 1)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_start_offset",
+    "title": "hmm_start_offset",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_start_offset' (type int, default 1)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_start_offset_fill_mode",
+    "title": "hmm_start_offset_fill_mode",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "backfill",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_start_offset_fill_mode' (type str, default 'backfill')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_backprojection_workers",
+    "title": "hmm_backprojection_workers",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 4,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_backprojection_workers' (type int, default 4)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_window_features",
+    "title": "hmm_window_features",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "list",
+    "default": [
+      "net_displacement"
+    ],
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_window_features' (type list, default ['net_displacement'])."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_window_features_window",
+    "title": "hmm_window_features_window",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 5,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_window_features_window' (type int, default 5)."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.hmm_log_scale_features",
+    "title": "hmm_log_scale_features",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "list",
+    "default": [
+      "speed",
+      "net_displacement"
+    ],
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.hmm_log_scale_features' (type list, default ['speed', 'net_displacement'])."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.feature_quantile_capping_low_percentile",
+    "title": "feature_quantile_capping_low_percentile",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.feature_quantile_capping_low_percentile' (type str, default '')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.feature_quantile_capping_high_percentile",
+    "title": "feature_quantile_capping_high_percentile",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.feature_quantile_capping_high_percentile' (type str, default '')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.apply_hmm_deployment_artifact_path",
+    "title": "apply_hmm_deployment_artifact_path",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.apply_hmm_deployment_artifact_path' (type str, default '')."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.selected_features",
+    "title": "selected_features",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "list",
+    "default": [
+      "elongation",
+      "extent",
+      "solidity",
+      "sphericity",
+      "speed"
+    ],
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.selected_features' (type list, default ['elongation', 'extent', 'solidity', 'sphericity', 'speed'])."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.binary_features_to_group",
+    "title": "binary_features_to_group",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "list",
+    "default": [
+      "any_immune_cell_contact",
+      "any_organoid_contact",
+      "dead",
+      "is_active_killing"
+    ],
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.binary_features_to_group' (type list, default ['any_immune_cell_contact', 'any_organoid_contact', 'dead', 'is_active_killing'])."
+  },
+  {
+    "key": "behavioral_state_classification.defaults.random_state",
+    "title": "random_state",
+    "step": "behavioral_state_classification",
+    "category": null,
+    "type": "int",
+    "default": 12345,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_state_classification.defaults.random_state' (type int, default 12345)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.behavioral_trajectory_size",
+    "title": "behavioral_trajectory_size",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 100,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.behavioral_trajectory_size' (type int, default 100)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.n_clusters",
+    "title": "n_clusters",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 6,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.n_clusters' (type int, default 6)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.n_per_cluster",
+    "title": "n_per_cluster",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 10,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.n_per_cluster' (type int, default 10)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.random_state",
+    "title": "random_state",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 12345,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.random_state' (type int, default 12345)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.trajectory_trim_mode",
+    "title": "trajectory_trim_mode",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "last",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.trajectory_trim_mode' (type str, default 'last')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.linkage",
+    "title": "linkage",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "average",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.linkage' (type str, default 'average')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.missing_policy",
+    "title": "missing_policy",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "keep",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.missing_policy' (type str, default 'keep')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.parallel",
+    "title": "parallel",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "bool",
+    "default": true,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.parallel' (type bool, default True)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.save_distance_matrix",
+    "title": "save_distance_matrix",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.save_distance_matrix' (type bool, default False)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.window",
+    "title": "window",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.window' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.max_dist",
+    "title": "max_dist",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.max_dist' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.max_length_diff",
+    "title": "max_length_diff",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.max_length_diff' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.penalty",
+    "title": "penalty",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.penalty' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.psi",
+    "title": "psi",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.psi' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.make_overview_statebars",
+    "title": "make_overview_statebars",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "bool",
+    "default": true,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.make_overview_statebars' (type bool, default True)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.make_backprojection_pdf",
+    "title": "make_backprojection_pdf",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.make_backprojection_pdf' (type bool, default False)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.make_backprojection_mp4",
+    "title": "make_backprojection_mp4",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "bool",
+    "default": false,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.make_backprojection_mp4' (type bool, default False)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_n_estimators",
+    "title": "classifier_n_estimators",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 100,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_n_estimators' (type int, default 100)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_min_samples_leaf",
+    "title": "classifier_min_samples_leaf",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 1,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_min_samples_leaf' (type int, default 1)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_min_samples_split",
+    "title": "classifier_min_samples_split",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": 2,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_min_samples_split' (type int, default 2)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_max_features",
+    "title": "classifier_max_features",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "sqrt",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_max_features' (type str, default 'sqrt')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_max_depth",
+    "title": "classifier_max_depth",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_max_depth' (type str, default '')."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_test_size",
+    "title": "classifier_test_size",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "float",
+    "default": 0.2,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_test_size' (type float, default 0.2)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_n_jobs",
+    "title": "classifier_n_jobs",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "int",
+    "default": -1,
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_n_jobs' (type int, default -1)."
+  },
+  {
+    "key": "behavioral_track_classification.defaults.classifier_artifact_path",
+    "title": "classifier_artifact_path",
+    "step": "behavioral_track_classification",
+    "category": null,
+    "type": "str",
+    "default": "",
+    "choices": null,
+    "description": "BEHAV3D parameter 'behavioral_track_classification.defaults.classifier_artifact_path' (type str, default '')."
+  },
+  {
+    "key": "viewer_display.channels",
+    "title": "channels",
+    "step": "viewer_display",
+    "category": null,
+    "type": "dict",
+    "default": {},
+    "choices": null,
+    "description": "BEHAV3D parameter 'viewer_display.channels' (type dict, default {})."
+  },
+  {
     "key": "calculated_features.morphology",
     "title": "morphology",
     "step": "feature_extraction",
@@ -2018,14 +2754,17 @@
       "equivalent_diameter",
       "major_axis_length",
       "minor_axis_length",
+      "axis1_length",
+      "axis2_length",
+      "axis3_length",
       "elongation",
       "surface_area",
       "sphericity",
       "convex_volume",
-      "orientation_vector"
+      "surface_to_volume_ratio"
     ],
     "choices": null,
-    "description": "Computed 'morphology' feature columns produced by BEHAV3D (reference, not user-tunable): nr_pixels, volume, bbox_volume, extent, solidity, equivalent_diameter, major_axis_length, minor_axis_length, elongation, surface_area, sphericity, convex_volume, orientation_vector."
+    "description": "Computed 'morphology' feature columns produced by BEHAV3D (reference, not user-tunable): nr_pixels, volume, bbox_volume, extent, solidity, equivalent_diameter, major_axis_length, minor_axis_length, axis1_length, axis2_length, axis3_length, elongation, surface_area, sphericity, convex_volume, surface_to_volume_ratio."
   },
   {
     "key": "calculated_features.movement",
@@ -2039,10 +2778,16 @@
       "displacement_from_origin",
       "mean_square_displacement",
       "speed",
-      "mean_speed"
+      "mean_speed",
+      "summed_displacement",
+      "net_displacement",
+      "straightness",
+      "directional_persistence",
+      "median_turning_angle",
+      "fraction_reversed_movement"
     ],
     "choices": null,
-    "description": "Computed 'movement' feature columns produced by BEHAV3D (reference, not user-tunable): displacement, cumulative_displacement, displacement_from_origin, mean_square_displacement, speed, mean_speed."
+    "description": "Computed 'movement' feature columns produced by BEHAV3D (reference, not user-tunable): displacement, cumulative_displacement, displacement_from_origin, mean_square_displacement, speed, mean_speed, summed_displacement, net_displacement, straightness, directional_persistence, median_turning_angle, fraction_reversed_movement."
   },
   {
     "key": "calculated_features.intensity",
@@ -2080,12 +2825,12 @@
     "type": "list",
     "default": [
       "*_contact",
+      "*_contact_on_distance",
       "*_contact_pixels",
-      "touching_*",
       "active_*_contact"
     ],
     "choices": null,
-    "description": "Computed 'contact' feature columns produced by BEHAV3D (reference, not user-tunable): *_contact, *_contact_pixels, touching_*, active_*_contact."
+    "description": "Computed 'contact' feature columns produced by BEHAV3D (reference, not user-tunable): *_contact, *_contact_on_distance, *_contact_pixels, active_*_contact."
   },
   {
     "key": "calculated_features.invasiveness",

--- a/docs/source/analysis/single_cell/state_classification.md
+++ b/docs/source/analysis/single_cell/state_classification.md
@@ -42,8 +42,8 @@ Optional clean-up applied to the chosen features before fitting:
 
 | Control | Default | Meaning | When to use |
 |---|---|---|---|
-| **Log scaling** (per-feature checkboxes) | none | Log-transform the ticked features. | For strongly skewed features (speed, mean square displacement) so a few large values don't dominate. |
-| **Smooth window** | 1 | Rolling-average smoothing applied to features (1 = no smoothing). | Increase slightly to damp frame-to-frame noise before fitting. |
+| **Log scaling** (per-feature checkboxes) | selected skewed features | Optionally apply `log1p` to the ticked features before the model standardises all continuous features. | Use for strongly right-skewed non-negative measurements; it is not required merely because features have different numeric ranges. |
+| **Smooth window** | 5 | Rolling-average smoothing applied to features (1 = no smoothing). | Increase slightly to damp frame-to-frame noise before fitting. |
 | **Low percentile cap** | 0.00 | Clip values below this quantile (0 = off). | Tame extreme low outliers. |
 | **High percentile cap** | 0.99 | Clip values above this quantile (1 = off). | Tame extreme high outliers (e.g. tracking spikes). |
 
@@ -154,6 +154,14 @@ Use Backprojection as a sanity check: scrub through time and the colours should 
 ```
 
 It is stored as an `.h5ad` data file that holds, for every cell at every timepoint, its assigned **intrinsic state** and its **full behavioural cluster** — using your chosen names after renaming. This is the file the Reports and the **Step 4 — Backprojection** step read.
+
+The HMM fit diagnostics, including the state-feature heatmap used to interpret each state, are saved at:
+
+```text
+<output_dir>/analysis/<cell_type>/behavioral_states/processing/hmm_behavioral_classification/quality_control/raw/behavioral_clustering_diagnostics.pdf
+```
+
+State Classification uses an **HMM on per-timepoint and rolling-window features**. The separate **Track Classification** tab contains whole-trajectory clustering, including the legacy DTW workflow; the two analyses answer different questions and should not be described interchangeably.
 
 The two reports are each saved as a PDF (the composition report also writes a CSV of the underlying curves).
 

--- a/test/fixtures/assistant_feedback_transcripts.json
+++ b/test/fixtures/assistant_feedback_transcripts.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "loaded_metadata_is_visible",
+    "step": "data_preparation",
+    "user": "I already added those details. Please check every sample.",
+    "required": ["loaded metadata is authoritative", "never ask the user to repeat"]
+  },
+  {
+    "id": "segmentation_method_ladder",
+    "step": "segmentation",
+    "user": "Which segmentation method should I use?",
+    "required": ["start with apoc", "random forest", "custom-trained cellpose", "tiff or zarr"],
+    "forbidden": ["apoc is the random forest"]
+  },
+  {
+    "id": "btrack_units_and_features",
+    "step": "tracking",
+    "user": "Help with btrack visual features, branching, and search radius.",
+    "required": ["physical distances", "global optimization is a separate", "p_branch only"]
+  },
+  {
+    "id": "filtering_tradeoff",
+    "step": "filtering",
+    "user": "What minimum track length should I use?",
+    "required": ["track-length distribution", "exclude real short-lived behavior", "downstream"]
+  },
+  {
+    "id": "hmm_not_dtw",
+    "step": "analysis",
+    "user": "Explain HMM windows, log scaling and where the heatmap is.",
+    "required": ["hmm", "legacy dtw", "window size", "smooth window", "standardized", "behavioral_clustering_diagnostics.pdf"]
+  },
+  {
+    "id": "death_preview",
+    "step": "feature_extraction",
+    "user": "What do the death preview colors mean?",
+    "required": ["green means alive", "red means dead", "hovering"]
+  },
+  {
+    "id": "metadata_based_edt",
+    "step": "segmentation",
+    "user": "Calcula el EDT segun la resolucion de mis imagenes.",
+    "required": ["10 um cell", "pixel_distance_xy", "20%, 25%, and 30%", "cell widths"]
+  },
+  {
+    "id": "interactive_track_counts",
+    "step": "filtering",
+    "user": "Si filtro a 200 timepoints, cuantos tracks quedan en position_t 0?",
+    "required": ["unique position_t", "requested position_t", "never estimate"]
+  }
+]

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -14,9 +14,24 @@ from behav3d.napari._assistant_schema import (
     flatten_config_to_cards, cards_for_step, dump_cards_json,
 )
 from behav3d.napari._assistant_actions import (
-    get_by_dotted, set_by_dotted, validate_value, build_actions,
+    get_by_dotted, set_by_dotted, validate_value, build_actions, apply_set_ui_value,
 )
-from behav3d.napari._assistant_context import summarize_metadata, _diff_from_defaults
+from behav3d.napari._assistant_context import (
+    summarize_metadata, _diff_from_defaults, validate_metadata_records,
+    _metadata_builder_state, build_context,
+)
+from behav3d.napari._assistant_controls import (
+    CONTROL_CONTRACT_VERSION, active_cell_type, control_registry,
+)
+from behav3d.napari._assistant_recommendations import (
+    calculate_edt_recommendations, format_edt_recommendations,
+)
+from behav3d.napari._assistant import researcher_facing_text
+from behav3d.analysis.track_counts import (
+    calculate_track_count_table, format_track_count_summary,
+    generate_track_count_summary,
+)
+from behav3d.napari._results_catalog import scan_outputs
 
 
 # --------------------------------------------------------------------------
@@ -138,46 +153,40 @@ def test_dump_cards_json(tmp_path=None):
 # --------------------------------------------------------------------------
 def test_app_tool_call_parsing_and_prompt():
     import app
-    txt = ('try ~12px.\n<TOOLCALL>{"name":"set_parameter",'
-           '"arguments":{"key":"cellpose.number_of_channels","value":2}}</TOOLCALL>')
+    txt = ('try 2 channels.\n<TOOLCALL>{"name":"set_ui_value",'
+           '"arguments":{"control_id":"segmentation.cellpose.number_of_channels",'
+           '"value":2}}</TOOLCALL>')
     clean, calls = app.parse_tool_calls(txt)
-    assert calls[0]["name"] == "set_parameter" and "<TOOLCALL>" not in clean
-    assert app.split_streamable(txt) == "try ~12px."
+    assert calls[0]["name"] == "set_ui_value" and "<TOOLCALL>" not in clean
+    assert app.split_streamable(txt) == "try 2 channels."
     assert app.parse_tool_calls("x <TOOLCALL>{bad}</TOOLCALL>")[1] == []
     sp = app.build_system_prompt(
         {"current_step": "tracking", "step_schema": [], "parameters": {}, "metadata": {}, "queue": []},
         [{"title": "btrack", "text": "good for crowded cells"}], [])
     assert "BEHAV3D" in sp and "good for crowded cells" in sp
-    sp2 = app.build_system_prompt(
-        {"current_step": "segmentation", "step_schema": [],
-         "required_params_at_default": [
-             {"key": "pixel_classifier.examples_per_sample", "default": 3, "description": "desc"},
-         ],
-         "assistant_session": {"confirmed_parameter_keys": ["pixel_classifier.examples_per_sample"]},
-         "parameters": {}, "metadata": {}, "queue": []},
-        [], [])
-    assert "CONFIRMED VALUES" in sp2
-    assert "PARAMS STILL AT DEFAULT" not in sp2
+    assert "at most the actions needed for this one user turn" in sp
 
 
 def test_tool_call_parsing_tolerates_malformed_markers():
     import app
     # the exact malformed shape a small model emitted: no leading '<', no closing tag
-    malformed = ('TOOLCALL>{"name": "set_parameter", "arguments": '
-                 '{"key": "paths.metadata_csv", "value": "/p/m.csv"}} '
-                 'TOOLCALL>{"name": "set_parameter", "arguments": '
-                 '{"key": "dim_order.default_apply_all", "value": "TZCYX"}}')
+    malformed = ('TOOLCALL>{"name": "set_ui_value", "arguments": '
+                 '{"control_id": "data.metadata_csv", "value": "/p/m.csv"}} '
+                 'TOOLCALL>{"name": "set_ui_value", "arguments": '
+                 '{"control_id": "data.dimension_order_all", "value": "TZCYX"}}')
     clean, calls = app.parse_tool_calls(malformed)
     assert len(calls) == 2 and "TOOLCALL" not in clean
-    assert calls[0]["arguments"]["key"] == "paths.metadata_csv"
+    assert calls[0]["arguments"]["control_id"] == "data.metadata_csv"
     # canonical form with nested args still parses and is stripped from display
     clean2, calls2 = app.parse_tool_calls(
-        'Sure.\n<TOOLCALL>{"name":"set_parameter","arguments":'
-        '{"key":"tracking.immune.method","value":"btrack"}}</TOOLCALL>')
+        'Sure.\n<TOOLCALL>{"name":"set_ui_value","arguments":'
+        '{"control_id":"tracking.tcell.method","value":"btrack"}}</TOOLCALL>')
     assert calls2[0]["arguments"]["value"] == "btrack" and clean2 == "Sure."
     # bare proposal form + list value
-    _, calls3 = app.parse_tool_calls('set_parameter{"key":"x","value":[100,100,10]}')
-    assert calls3[0]["arguments"]["value"] == [100, 100, 10]
+    _, calls3 = app.parse_tool_calls(
+        'set_ui_value{"control_id":"features.tcell.feature_groups",'
+        '"value":["movement","contact"]}')
+    assert calls3[0]["arguments"]["value"] == ["movement", "contact"]
     clean4, calls4 = app.parse_tool_calls(
         'Done.\nfill_metadata_builder{"field":"n_samples","value":3}')
     assert clean4 == "Done."
@@ -188,28 +197,28 @@ def test_tool_call_parsing_tolerates_malformed_markers():
 def test_to_openai_tools_injects_key_enum():
     import app
     from behav3d.napari._assistant_actions import TOOL_SCHEMA
-    enum = ["paths.metadata_csv", "tracking.immune.method"]
+    enum = ["data.metadata_csv", "tracking.tcell.method"]
     tools = app.to_openai_tools(TOOL_SCHEMA, key_enum=enum)
     assert all(t["type"] == "function" for t in tools)
-    sp = next(t for t in tools if t["function"]["name"] == "set_parameter")
-    assert sp["function"]["parameters"]["properties"]["key"]["enum"] == enum
+    sp = next(t for t in tools if t["function"]["name"] == "set_ui_value")
+    assert sp["function"]["parameters"]["properties"]["control_id"]["enum"] == enum
     # original schema is not mutated (deep-copied)
-    assert "enum" not in TOOL_SCHEMA[0]["parameters"]["properties"]["key"]
+    assert "enum" not in TOOL_SCHEMA[0]["parameters"]["properties"]["control_id"]
 
 
 def test_assemble_tool_calls_merges_streamed_fragments():
     import app
     frags = [
-        {"index": 0, "name": "set_parameter", "arguments": ""},
-        {"index": 0, "name": None, "arguments": '{"key": "tracking.immune'},
-        {"index": 0, "name": None, "arguments": '.trackpy.search_range_px", "value": 40}'},
+        {"index": 0, "name": "set_ui_value", "arguments": ""},
+        {"index": 0, "name": None, "arguments": '{"control_id": "tracking.tcell'},
+        {"index": 0, "name": None, "arguments": '.trackpy.search_range", "value": 40}'},
     ]
     calls = app.assemble_tool_calls(frags)
-    assert calls == [{"name": "set_parameter",
-                      "arguments": {"key": "tracking.immune.trackpy.search_range_px",
+    assert calls == [{"name": "set_ui_value",
+                      "arguments": {"control_id": "tracking.tcell.trackpy.search_range",
                                     "value": 40}}]
     # incomplete / unparseable arguments are dropped, not crashed on
-    assert app.assemble_tool_calls([{"index": 0, "name": "set_parameter",
+    assert app.assemble_tool_calls([{"index": 0, "name": "set_ui_value",
                                      "arguments": "{bad"}]) == []
 
 
@@ -266,10 +275,30 @@ def test_new_tools_registered():
     import app
     from behav3d.napari._assistant_actions import TOOL_SCHEMA
     names = {t["name"] for t in TOOL_SCHEMA}
-    assert {"bulk_fill_metadata", "select_segmentation_method"} <= names
+    assert {"set_ui_value", "bulk_fill_metadata", "show_track_length_distribution",
+            "create_cell_type_group", "create_btrack_config_copy", "open_result",
+            "recommend_edt", "summarize_track_counts"} <= names
+    assert "set_parameter" not in names
     # the backend text-fallback parser must also recognise the new tool names
     assert "bulk_fill_metadata" in app._TOOL_NAMES
-    assert "select_segmentation_method" in app._TOOL_NAMES
+    assert "set_ui_value" in app._TOOL_NAMES
+    assert "recommend_edt" in app._TOOL_NAMES
+    assert "summarize_track_counts" in app._TOOL_NAMES
+
+
+def test_build_actions_for_edt_and_track_count_queries():
+    actions = build_actions([
+        {"name": "recommend_edt", "arguments": {
+            "cell_type": "tcell", "cell_diameter_um": 10,
+        }},
+        {"name": "summarize_track_counts", "arguments": {
+            "cell_type": "tcell", "position_t": 200,
+            "minimum_lengths": [200, 30, 30],
+        }},
+    ], [], {})
+    assert actions[0].ok and actions[0].kind == "recommend_edt"
+    assert actions[1].ok and actions[1].data["minimum_lengths"] == [30, 200]
+    assert actions[1].data["position_t"] == 200
 
 
 def test_prompt_data_prep_reconciles_state_and_lists_tools():
@@ -281,13 +310,436 @@ def test_prompt_data_prep_reconciles_state_and_lists_tools():
                               "immune_names": ["tcell"]},
          "queue": []},
         [], [])
-    # CONTEXT no longer claims "0 samples" while the builder holds values.
-    assert "Samples being entered in Metadata Builder: 22" in sp
-    assert "Metadata CSV loaded: False" in sp
-    # New tools are advertised, and the guide tells the model not to re-ask.
-    assert "bulk_fill_metadata" in sp
-    assert "select_segmentation_method" in sp
-    assert "NEVER re-ask" in sp or "never re-ask" in sp.lower()
+    # The full builder state is represented as structured context.
+    assert '"n_samples": 22' in sp
+    assert '"loaded": false' in sp
+    assert "Never ask for a value already present" in sp
+    assert "n_samples" in sp  # present only as structured live context
+
+
+def test_prompt_treats_metadata_builder_draft_as_current():
+    import app
+    sp = app.build_system_prompt(
+        {"current_step": "segmentation", "metadata": {
+            "loaded": True, "record_source": "metadata_builder_draft",
+            "records": [{"sample_name": "Sample01", "dimension_order": "TCZYX"}],
+            "validation": [], "save_required": True,
+        }, "metadata_builder": {"open": True}, "queue": []},
+        [], [])
+    assert "supersede the last saved DataFrame" in sp
+    assert "draft changes still need to be saved" in sp
+
+
+class _FakeSpin:
+    def __init__(self, value, minimum=0, maximum=9999):
+        self._value = value
+        self._minimum = minimum
+        self._maximum = maximum
+
+    def value(self): return self._value
+    def setValue(self, value): self._value = type(self._value)(value)
+    def minimum(self): return self._minimum
+    def maximum(self): return self._maximum
+    def isEnabled(self): return True
+    def isHidden(self): return False
+
+
+class _FakeCheck:
+    def __init__(self, checked=False): self._checked = checked
+    def isChecked(self): return self._checked
+    def setChecked(self, value): self._checked = bool(value)
+    def isEnabled(self): return True
+    def isHidden(self): return False
+
+
+class _FakeLine:
+    def __init__(self, value=""): self._value = value
+    def text(self): return self._value
+    def setText(self, value): self._value = str(value)
+    def isEnabled(self): return True
+    def isHidden(self): return False
+
+
+class _FakeGroup:
+    def __init__(self, title="Sample 1", checked=True):
+        self._title, self._checked = title, checked
+    def title(self): return self._title
+    def isChecked(self): return self._checked
+
+
+class _FakeCombo:
+    def __init__(self, items, index=0): self.items, self.index = list(items), index
+    def count(self): return len(self.items)
+    def itemText(self, index): return self.items[index]
+    def currentText(self): return self.items[self.index]
+    def currentIndex(self): return self.index
+    def setCurrentIndex(self, index): self.index = index
+    def isEnabled(self): return True
+    def isHidden(self): return False
+
+
+class _FakeTabs:
+    def __init__(self, panel): self.panel = panel
+    def currentWidget(self): return self.panel
+
+
+class _FakeWorkflowTabs:
+    def __init__(self, index=0): self.index = index
+    def currentIndex(self): return self.index
+    def setCurrentIndex(self, index): self.index = index
+    def tabText(self, index):
+        return ["Data Preparation", "Visualization", "Segmentation"][index]
+
+
+class _FakeTrackingPanel:
+    def __init__(self, cell_type, radius):
+        self.cell_type = cell_type
+        self.combo_method = _FakeCombo(["LAP", "TrackPy", "Propagation", "btrack"], 3)
+        self.lap_merge_cost = _FakeSpin(0)
+        self.lap_split_cost = _FakeSpin(0)
+        self.tp_adaptive_stop = _FakeSpin(10.0)
+        self.tp_adaptive_step = _FakeSpin(0.95)
+        self.bt_max_search_radius = _FakeSpin(radius, 1, 9999)
+        self.bt_use_visual_features = _FakeCheck(False)
+        self.bt_use_optimize = _FakeCheck(False)
+        self.bt_hyp_checks = {"P_FP": _FakeCheck(True), "P_branch": _FakeCheck(False)}
+        self.persisted = 0
+
+    def _persist(self): self.persisted += 1
+
+
+def test_live_control_registry_targets_actual_cell_type_only():
+    from types import SimpleNamespace
+    tcell = _FakeTrackingPanel("tcell", 100)
+    organoid = _FakeTrackingPanel("organoid1", 200)
+    tracking = SimpleNamespace(
+        panels={"tcell": tcell, "organoid1": organoid},
+        cell_tabs=_FakeTabs(tcell),
+    )
+    main = SimpleNamespace(tracking_tab=tracking)
+    controls = control_registry(main)
+    ids = {item["id"] for item in controls}
+    assert "tracking.tcell.btrack.maximum_search_radius" in ids
+    assert "tracking.organoid1.btrack.maximum_search_radius" in ids
+    assert "tracking.tcell.lap.merging_distance" in ids
+    assert "tracking.tcell.trackpy.adaptive_step" in ids
+    assert active_cell_type(main, "tracking") == "tcell"
+    assert apply_set_ui_value(main, "tracking.tcell.btrack.maximum_search_radius", 125)
+    assert tcell.bt_max_search_radius.value() == 125
+    assert organoid.bt_max_search_radius.value() == 200
+    assert tcell.persisted == 1 and organoid.persisted == 0
+
+
+def test_apoc_same_value_is_noop_and_method_specific():
+    from types import SimpleNamespace
+    method = _FakeCombo([
+        "APOC (GPU)", "ConvPaint", "Pixel Classifier (Random Forest)",
+        "Cellpose", "Import segmentation",
+    ], 0)
+    seg = SimpleNamespace(
+        method_combo=method,
+        apoc_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        convpaint_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        pixel_classifier_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        cellpose_page=SimpleNamespace(),
+    )
+    main = SimpleNamespace(segmentation_tab=seg)
+    controls = control_registry(main)
+    visible = {item["id"] for item in controls if item["visible"]}
+    assert "segmentation.apoc.examples_per_sample" in visible
+    assert "segmentation.random_forest.examples_per_sample" not in visible
+    actions = build_actions([{
+        "name": "set_ui_value",
+        "arguments": {"control_id": "segmentation.apoc.examples_per_sample", "value": 3},
+    }], [], {}, controls=controls)
+    assert len(actions) == 1 and actions[0].data.get("no_op") is True
+    assert not actions[0].ok  # no confirmation card should be rendered
+
+
+def test_metadata_records_are_complete_and_validated():
+    import pandas as pd
+    frame = pd.DataFrame([
+        {"sample_name": "s1", "raw_image_path": "/missing/a.tif",
+         "dimension_order": "TCZYX", "pixel_distance_xy": 0.5,
+         "pixel_distance_z": 2.0, "time_interval": 5, "time_unit": "min",
+         "im_tcell_line_condition": "Jurkat_control"},
+        {"sample_name": "s2", "raw_image_path": "/missing/b.tif",
+         "dimension_order": "ZCTXY", "pixel_distance_xy": 0.5,
+         "pixel_distance_z": 2.0, "time_interval": 5, "time_unit": "min",
+         "im_tcell_line_condition": "Jurkat_treated"},
+    ])
+    summary = summarize_metadata(frame)
+    assert len(summary["records"]) == 2
+    assert summary["records"][1]["im_tcell_line_condition"] == "Jurkat_treated"
+    assert any(issue["field"] == "dimension_order" and issue["severity"] == "error"
+               for issue in summary["validation"])
+
+
+def test_metadata_builder_draft_validation_uses_live_form_value():
+    from types import SimpleNamespace
+    form = {
+        "group": _FakeGroup(),
+        "basic": {
+            "sample_name": _FakeLine("Sample01"),
+            "raw_image_path": _FakeLine("/missing/sample.tif"),
+            "dimension_order": _FakeLine("TCZYX"),
+            "pixel_distance_xy": _FakeSpin(0.5),
+            "pixel_distance_z": _FakeSpin(2.0),
+            "time_interval": _FakeSpin(5.0),
+            "time_unit": _FakeCombo(["s", "m", "h"], 1),
+        },
+        "dead_channel": {}, "cell_types": {},
+    }
+    dp = SimpleNamespace(
+        builder_grp=_FakeGroup(checked=True), _sample_forms=[form],
+        n_samples_spin=_FakeSpin(1), n_organoid_spin=_FakeSpin(0),
+        n_immune_spin=_FakeSpin(0), n_other_spin=_FakeSpin(0),
+        include_dead_cb=_FakeCheck(False), _organoid_name_edits=[],
+        _immune_name_edits=[], _other_name_edits=[],
+    )
+    state = _metadata_builder_state(dp)
+    assert state["draft_records"][0]["dimension_order"] == "TCZYX"
+    assert not any(issue["field"] == "dimension_order"
+                   for issue in state["draft_validation"])
+
+
+def test_context_keeps_builder_draft_authoritative_after_tab_switch():
+    import pandas as pd
+    from types import SimpleNamespace
+    form = {
+        "group": _FakeGroup(),
+        "basic": {
+            "sample_name": _FakeLine("Sample01"),
+            "raw_image_path": _FakeLine("/missing/sample.tif"),
+            "dimension_order": _FakeLine("TCZYX"),
+            "pixel_distance_xy": _FakeSpin(0.5),
+            "pixel_distance_z": _FakeSpin(2.0),
+            "time_interval": _FakeSpin(5.0),
+            "time_unit": _FakeCombo(["s", "m", "h"], 1),
+        },
+        "dead_channel": {}, "cell_types": {},
+    }
+    # The saved DataFrame still has the old blank value while the live draft has
+    # already been corrected. This is the exact state from the reported loop.
+    dp = SimpleNamespace(
+        metadata=pd.DataFrame([{
+            "sample_name": "Sample01", "raw_image_path": "/missing/sample.tif",
+            "dimension_order": None, "pixel_distance_xy": 0.5,
+            "pixel_distance_z": 2.0, "time_interval": 5.0, "time_unit": "m",
+        }]),
+        output_dir="", behav3d_parameters={},
+        builder_grp=_FakeGroup(checked=True), _sample_forms=[form],
+        n_samples_spin=_FakeSpin(1), n_organoid_spin=_FakeSpin(0),
+        n_immune_spin=_FakeSpin(0), n_other_spin=_FakeSpin(0),
+        include_dead_cb=_FakeCheck(False), _organoid_name_edits=[],
+        _immune_name_edits=[], _other_name_edits=[],
+    )
+    context = build_context(SimpleNamespace(
+        tabs=_FakeWorkflowTabs(2), data_prep_tab=dp,
+    ))
+    assert context["current_step"] == "segmentation"
+    assert context["metadata"]["record_source"] == "metadata_builder_draft"
+    assert context["metadata"]["records"][0]["dimension_order"] == "TCZYX"
+    assert not any(issue["field"] == "dimension_order"
+                   for issue in context["metadata"]["validation"])
+    assert context["metadata_builder"]["open"] is True
+
+
+def test_live_registry_covers_filtering_and_hmm_controls():
+    from types import SimpleNamespace
+    filter_panel = SimpleNamespace(
+        en_exp_duration=_FakeCheck(True), spin_exp_duration=_FakeSpin(350),
+        en_min_length=_FakeCheck(True), spin_min_length=_FakeSpin(30),
+        en_max_length=_FakeCheck(True), spin_max_length=_FakeSpin(30),
+        check_filter_min_size=_FakeCheck(False), spin_min_size_t1=_FakeSpin(1000),
+        check_filter_dead_t0=_FakeCheck(False),
+        combo_time_type=_FakeCombo(["frames", "hours"]),
+    )
+    state = SimpleNamespace(
+        spin_window_size=_FakeSpin(5),
+        spin_hmm_feature_smoothing_window=_FakeSpin(5),
+        spin_hmm_n_states=_FakeSpin(4),
+        combo_hmm_n_states_mode=_FakeCombo(["fixed", "auto"]),
+        spin_hmm_k_min=_FakeSpin(2), spin_hmm_k_max=_FakeSpin(8),
+        chk_hmm_sticky=_FakeCheck(False),
+        _timepoint_checkboxes={}, _logscale_checkboxes={}, _bingrp_checkboxes={},
+    )
+    main = SimpleNamespace(
+        filtering_tab=SimpleNamespace(panels={"tcell": filter_panel}),
+        analysis_tab=SimpleNamespace(single_cell_tab=SimpleNamespace(
+            cell_type_combo=_FakeCombo(["tcell"]), state_tab=state,
+        )),
+    )
+    controls = {item["id"]: item for item in control_registry(main)}
+    assert "filtering.tcell.minimum_initial_size.enabled" in controls
+    assert "filtering.tcell.dead_at_first_timepoint.enabled" in controls
+    assert "filtering.tcell.time_unit" in controls
+    states = "analysis.state_classification.tcell.number_of_states"
+    assert states in controls and controls[states]["value"] == 4
+    assert controls[states]["visible"] is True
+
+
+def test_edt_recommendations_use_per_sample_xy_resolution():
+    result = calculate_edt_recommendations([
+        {"sample_name": "Well_A1", "pixel_distance_xy": 0.5,
+         "distance_unit": "um"},
+        {"sample_name": "Well_A2", "pixel_distance_xy": 1000,
+         "distance_unit": "nm"},
+    ])
+    assert result["rows"][0]["object_diameter_px"] == 20
+    assert result["rows"][0]["edt_candidates_px"] == [4, 5, 6]
+    assert result["rows"][1]["object_diameter_px"] == 10
+    assert result["rows"][1]["edt_candidates_px"] == [2, 2.5, 3]
+    text = format_edt_recommendations(result, "tcell")
+    assert "Well_A1" in text and "global starting value" in text
+
+    organoid = calculate_edt_recommendations(
+        [{"sample_name": "Org", "pixel_distance_xy": 0.5,
+          "distance_unit": "um"}],
+        organoid_cells_across=5,
+    )
+    assert organoid["object_diameter_um"] == 50
+    assert organoid["rows"][0]["object_diameter_px"] == 100
+
+
+def test_streamed_assistant_text_uses_researcher_facing_labels():
+    text = researcher_facing_text(
+        "pixel_distance_xy is 0.5; position_t is 10 for sample_name and TrackID."
+    )
+    assert text == "XY pixel size is 0.5; timepoint is 10 for sample name and track ID."
+
+
+def test_segmentation_registry_exposes_exact_edt_control():
+    from types import SimpleNamespace
+    edt = _FakeSpin(2.5, 0.0, 50.0)
+    random_forest = SimpleNamespace(
+        spin_examples=_FakeSpin(3),
+        param_widgets={"tcell": {"edt": edt}},
+        _persist_params=lambda: None,
+    )
+    segmentation = SimpleNamespace(
+        method_combo=_FakeCombo([
+            "APOC (GPU)", "ConvPaint", "Pixel Classifier (Random Forest)",
+            "Cellpose", "Import segmentation",
+        ], 2),
+        apoc_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        convpaint_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        pixel_classifier_page=random_forest,
+        cellpose_page=SimpleNamespace(),
+    )
+    main = SimpleNamespace(segmentation_tab=segmentation)
+    controls = {item["id"]: item for item in control_registry(main)}
+    control_id = "segmentation.random_forest.tcell.edt_threshold"
+    assert control_id in controls and controls[control_id]["visible"] is True
+    assert apply_set_ui_value(main, control_id, 5.0)
+    assert edt.value() == 5.0
+
+
+def test_active_segmentation_cell_type_uses_method_subtab():
+    from types import SimpleNamespace
+    training = SimpleNamespace(
+        tab_widget=_FakeCombo(["tcell", "organoid1"], 1),
+        _tab_cell_types=["tcell", "organoid1"],
+    )
+    main = SimpleNamespace(segmentation_tab=SimpleNamespace(
+        method_combo=_FakeCombo(["APOC", "ConvPaint"], 0),
+        apoc_page=SimpleNamespace(_training_widget=training),
+    ))
+    assert active_cell_type(main, "segmentation") == "organoid1"
+
+
+def test_track_count_table_filters_full_track_length_at_requested_timepoint():
+    import pandas as pd
+    rows = []
+    for timepoint in range(20):
+        rows.append({"sample_name": "Well_A1", "TrackID": 1,
+                     "position_t": timepoint})
+    for timepoint in range(50):
+        rows.append({"sample_name": "Well_A1", "TrackID": 2,
+                     "position_t": timepoint})
+    for timepoint in range(1, 201):
+        rows.append({"sample_name": "Well_A1", "TrackID": 3,
+                     "position_t": timepoint})
+    rows.extend([
+        {"sample_name": "Well_A2", "TrackID": 1, "position_t": 0},
+        {"sample_name": "Well_A2", "TrackID": 1, "position_t": 0},
+    ])
+    frame = pd.DataFrame(rows)
+    table, details = calculate_track_count_table(
+        frame, minimum_lengths=[20, 50, 100, 200], position_t=0
+    )
+    a1 = table.loc[table["sample_name"] == "Well_A1"].iloc[0]
+    assert a1["Cell count at timepoint 0 (not filtered)"] == 2
+    assert a1[">=20 timepoints"] == 2
+    assert a1[">=50 timepoints"] == 1
+    assert a1[">=100 timepoints"] == 0
+    assert details["position_present"] is True
+
+    at_200, _ = calculate_track_count_table(
+        frame, minimum_lengths=[30, 200], position_t=200
+    )
+    a1_200 = at_200.loc[at_200["sample_name"] == "Well_A1"].iloc[0]
+    assert a1_200[">=200 timepoints"] == 1
+
+
+def test_track_count_summary_is_saved_under_quality_control(tmp_path=None):
+    import pandas as pd
+    import tempfile
+    from pathlib import Path
+    root = Path(tmp_path or tempfile.mkdtemp())
+    source = root / "analysis" / "tcell" / "track_features"
+    source.mkdir(parents=True)
+    pd.DataFrame([
+        {"sample_name": "Well_A1", "TrackID": 1, "position_t": timepoint}
+        for timepoint in range(30)
+    ]).to_csv(source / "BEHAV3D_tcell_combined_track_features.csv", index=False)
+    result = generate_track_count_summary(
+        root, "tcell", minimum_lengths=[20, 50, 100, 200], position_t=0
+    )
+    assert result["output_path"].is_file()
+    assert result["output_path"].parent.name == "quality_control"
+    assert result["output_path"].name == "BEHAV3D_tcell_track_count_summary.csv"
+    markdown = format_track_count_summary(result, "tcell")
+    assert "| Sample |" in markdown
+    assert "sample_name" not in markdown
+    query = generate_track_count_summary(
+        root, "tcell", minimum_lengths=[30], position_t=20
+    )
+    assert query["output_path"].is_file()
+    assert query["output_path"] != result["output_path"]
+    catalog_entry = next(
+        item for item in scan_outputs(root)
+        if item.path == result["output_path"]
+    )
+    assert catalog_entry.category == "filtering"
+    assert "timepoint 0" in catalog_entry.description
+
+
+def test_feedback_guidance_fixtures():
+    import json
+    from pathlib import Path
+    from guidance import KNOWLEDGE_VERSION, select_guidance_cards
+
+    fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
+    cases = json.loads(fixture.read_text(encoding="utf-8"))
+    assert KNOWLEDGE_VERSION == "2026.07.14.2"
+    for case in cases:
+        cards = select_guidance_cards(
+            {"current_step": case["step"]}, case["user"], case.get("intent"))
+        text = " ".join(card["text"] for card in cards).lower()
+        for required in case.get("required", []):
+            assert required.lower() in text, (case["id"], required)
+        for forbidden in case.get("forbidden", []):
+            assert forbidden.lower() not in text, (case["id"], forbidden)
+
+
+def test_assistant_has_no_hidden_model_continuation():
+    from pathlib import Path
+    source = (Path(__file__).parents[1] / "behav3d" / "napari" / "_assistant.py").read_text()
+    assert "def _auto_continue" not in source
+    assert "_dispatch_proactive" not in source
+    assert "Checking your setup" not in source
+    assert CONTROL_CONTRACT_VERSION == "2.0"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- ground the assistant in live controls, loaded metadata, and unsaved Metadata Builder drafts
- remove hidden continuation loops and make same-value actions complete without repeated prompts
- expose dynamic per-cell-type controls with researcher-facing labels and safer confirmation behavior
- add metadata-based EDT recommendations for cells and organoids
- add Filtering track-count summaries with arbitrary minimum-length and timepoint queries
- refresh the assistant UI, deterministic guidance cards, results catalog, and regression fixtures

## Why

PI testing found that the assistant could ask for values already entered, expose internal variable names, repeat no-op actions indefinitely, struggle with dynamic metadata/segmentation forms, and provide confusing button-driven guidance. Filtering also lacked an interactive way to estimate how minimum track lengths affect the number of cells available for analysis.

## User impact

The assistant now reads the current UI state before responding, targets exact visible controls, and keeps one user turn to one model request. Researchers can ask it to estimate EDT values from experiment resolution, apply the selected value to the correct segmentation method, and generate per-sample track-count tables from the unfiltered feature CSV. Generated summaries are saved under Filtering quality-control results.

## Validation

- `36/36` standalone assistant tests pass
- all touched Python modules compile with `py_compile`
- `git diff --check` passes
- direct API conversations verified EDT, organoid clarification, exact-value application, standard Filtering summaries, arbitrary thresholds, arbitrary timepoints, no-op progression, and resolved metadata behavior
- deterministic calculations were exercised against the supplied `behav3d-test` track-feature data using a temporary output copy

## Follow-up

- redeploy the Modal service after merge so it uses the final prompt wording in this PR
- confirm the provisional EDT trial fractions (20%, 25%, and 30% of expected XY diameter) with the segmentation domain owners
