### PR TITLE
Address second-round chatbot feedback

### DIFF
--- a/behav3d/napari/_assistant_actions.py
+++ b/behav3d/napari/_assistant_actions.py
@@ -1466,7 +1466,9 @@ TOOL_SCHEMA = [
         "description": (
             "Set one exact field that exists in ui_state.controls. Use its id exactly. "
             "Never invent an id and never use internal configuration keys. Blank fields "
-            "may apply immediately; changing an existing value requires confirmation."
+            "may apply immediately; changing an existing value requires confirmation. "
+            "When the user explicitly asks to fill or change available values, emit the "
+            "corresponding calls now instead of only describing the intended changes."
         ),
         "parameters": {
             "type": "object",
@@ -1576,7 +1578,11 @@ TOOL_SCHEMA = [
         "description": (
             "Fill the ENTIRE Metadata Builder in ONE call. Use this (instead of "
             "many fill_metadata_builder calls) when the user gives lots of values "
-            "at once, provides a list of image files, or says 'fill everything'. "
+            "at once, describes a new multi-sample experiment, provides a list of image "
+            "files, or says 'fill everything'. Unknown fields may be omitted; include one "
+            "possibly partial sample object per described movie so the forms are created. "
+            "Never guess dimension_order, time_unit, image paths, sample names, or wells. "
+            "This action opens the Metadata Builder itself; do not call open_builder first. "
             "The app rebuilds the forms once and applies all values in a single "
             "pass with no per-field confirmation. Provide the population counts, "
             "cell-type name lists, and one dict per sample."

--- a/behav3d/napari/_assistant_context.py
+++ b/behav3d/napari/_assistant_context.py
@@ -435,7 +435,7 @@ def _step_readiness(main_widget, ctx: dict) -> dict:
 
 
 def _segmentation_state(main_widget) -> dict:
-    """Snapshot the visible segmentation method selector."""
+    """Snapshot the visible method and per-cell instance strategies."""
     seg = _safe(lambda: getattr(main_widget, "segmentation_tab", None))
     combo = _safe(lambda: getattr(seg, "method_combo", None))
     if combo is None:
@@ -444,11 +444,32 @@ def _segmentation_state(main_widget) -> dict:
         methods = [combo.itemText(i) for i in range(combo.count())]
     except Exception:
         methods = []
-    return {
+    state = {
         "method": _safe(lambda: combo.currentText(), ""),
         "method_index": _safe(lambda: combo.currentIndex(), 0),
         "available_methods": methods,
     }
+    for token, page_attr in (("apoc", "apoc_page"), ("convpaint", "convpaint_page")):
+        page = getattr(seg, page_attr, None)
+        training = getattr(page, "_training_widget", None) if page is not None else None
+        if training is None:
+            continue
+        global_combo = getattr(training, "strategy_combo", None)
+        global_strategy = (
+            _safe(lambda c=global_combo: c.currentText(), "") if global_combo is not None else ""
+        )
+        by_cell_type = {}
+        for cell_type, tab in (getattr(training, "tabs", {}) or {}).items():
+            per_tab = getattr(tab, "_per_tab_strategy_combo", None)
+            by_cell_type[str(cell_type)] = (
+                _safe(lambda c=per_tab: c.currentText(), "")
+                if per_tab is not None else global_strategy
+            )
+        state[token] = {
+            "global_strategy": global_strategy or None,
+            "cell_type_strategies": by_cell_type,
+        }
+    return state
 
 
 def _required_params_at_default(

--- a/behav3d/napari/_assistant_controls.py
+++ b/behav3d/napari/_assistant_controls.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 
-CONTROL_CONTRACT_VERSION = "2.0"
+CONTROL_CONTRACT_VERSION = "2.5"
 
 
 def _safe(fn: Callable, default=None):
@@ -98,6 +98,7 @@ def _binding(
     default: Any = None,
     unit: str | None = None,
     method: str | None = None,
+    strategy: str | None = None,
     cell_type: str | None = None,
     visible: bool | None = None,
     getter: Callable | None = None,
@@ -118,6 +119,7 @@ def _binding(
         "enabled": _is_enabled(widget),
         "step": step,
         "method": method,
+        "strategy": strategy,
         "cell_type": cell_type,
         "_widget": widget,
         "_getter": get,
@@ -252,45 +254,83 @@ def _segmentation_bindings(main_widget) -> list[dict]:
                 persist=getattr(page, persist_name, None),
             ))
 
-    # EDT fields are created dynamically per cell type and per strategy. Expose
-    # only fields that currently exist, using the same binding for context and
-    # application so recommendations can be applied to the exact visible method.
+    def instance_strategy(training, tab) -> str | None:
+        per_tab = getattr(tab, "_per_tab_strategy_combo", None)
+        global_combo = getattr(training, "strategy_combo", None)
+        combo = per_tab if per_tab is not None else global_combo
+        return _safe(combo.currentText, None) if combo is not None else None
+
+    # Instance-segmentation fields are created dynamically for the selected
+    # strategy. Expose only controls that actually exist so advice and edits are
+    # grounded in the active method, cell type, and watershed strategy.
     apoc = getattr(seg, "apoc_page", None)
     apoc_training = getattr(apoc, "_training_widget", None) if apoc is not None else None
     for cell_type, tab in (getattr(apoc_training, "tabs", {}) or {}).items():
-        widget = getattr(tab, "edt_threshold_spin", None)
-        if widget is None:
-            continue
-
         def persist_apoc(page=apoc):
             page._save_apoc_params_to_yaml(
                 updated_apoc_params=page._collect_apoc_tab_config()
             )
 
-        out.append(_binding(
-            f"segmentation.apoc.{cell_type}.edt_threshold",
-            f"{cell_type}: APOC EDT threshold", widget,
-            step="segmentation", unit="pixels", method="APOC",
-            cell_type=str(cell_type), visible=current_index == 0,
-            persist=persist_apoc,
-        ))
+        strategy = instance_strategy(apoc_training, tab)
+        strategy_combo = getattr(tab, "_per_tab_strategy_combo", None)
+        if strategy_combo is not None:
+            out.append(_binding(
+                f"segmentation.apoc.{cell_type}.strategy",
+                f"{cell_type}: APOC instance segmentation strategy",
+                strategy_combo, step="segmentation", method="APOC",
+                strategy=strategy, cell_type=str(cell_type),
+                visible=current_index == 0, persist=persist_apoc,
+            ))
+        for suffix, label, attr, unit in (
+            ("mask_threshold", "mask threshold", "prob_mask_threshold_spin", None),
+            ("seed_threshold", "seed threshold", "prob_seed_threshold_spin", None),
+            ("edt_threshold", "EDT threshold", "edt_threshold_spin", "pixels"),
+        ):
+            widget = getattr(tab, attr, None)
+            if widget is None:
+                continue
+            out.append(_binding(
+                f"segmentation.apoc.{cell_type}.{suffix}",
+                f"{cell_type}: APOC {label}", widget,
+                step="segmentation", unit=unit, method="APOC",
+                strategy=strategy, cell_type=str(cell_type),
+                visible=current_index == 0, persist=persist_apoc,
+            ))
 
     convpaint = getattr(seg, "convpaint_page", None)
     conv_training = (
         getattr(convpaint, "_training_widget", None) if convpaint is not None else None
     )
     for cell_type, tab in (getattr(conv_training, "tabs", {}) or {}).items():
-        widget = getattr(tab, "edt_threshold_spin", None)
-        if widget is None:
-            continue
-        out.append(_binding(
-            f"segmentation.convpaint.{cell_type}.edt_threshold",
-            f"{cell_type}: ConvPaint EDT threshold", widget,
-            step="segmentation", unit="pixels", method="ConvPaint",
-            cell_type=str(cell_type), visible=current_index == 1,
-            persist=(lambda page=convpaint, training_tab=tab:
-                     page._save_params_to_yaml(training_tab.collect_params())),
-        ))
+        strategy = instance_strategy(conv_training, tab)
+
+        def persist_convpaint(page=convpaint, training_tab=tab):
+            page._save_params_to_yaml(training_tab.collect_params())
+
+        strategy_combo = getattr(tab, "_per_tab_strategy_combo", None)
+        if strategy_combo is not None:
+            out.append(_binding(
+                f"segmentation.convpaint.{cell_type}.strategy",
+                f"{cell_type}: ConvPaint instance segmentation strategy",
+                strategy_combo, step="segmentation", method="ConvPaint",
+                strategy=strategy, cell_type=str(cell_type),
+                visible=current_index == 1, persist=persist_convpaint,
+            ))
+        for suffix, label, attr, unit in (
+            ("mask_threshold", "mask threshold", "prob_mask_threshold_spin", None),
+            ("seed_threshold", "seed threshold", "prob_seed_threshold_spin", None),
+            ("edt_threshold", "EDT threshold", "edt_threshold_spin", "pixels"),
+        ):
+            widget = getattr(tab, attr, None)
+            if widget is None:
+                continue
+            out.append(_binding(
+                f"segmentation.convpaint.{cell_type}.{suffix}",
+                f"{cell_type}: ConvPaint {label}", widget,
+                step="segmentation", unit=unit, method="ConvPaint",
+                strategy=strategy, cell_type=str(cell_type),
+                visible=current_index == 1, persist=persist_convpaint,
+            ))
 
     random_forest = getattr(seg, "pixel_classifier_page", None)
     for cell_type, widgets in (getattr(random_forest, "param_widgets", {}) or {}).items():
@@ -344,7 +384,14 @@ def _tracking_bindings(main_widget) -> list[dict]:
     ]
     for cell_type, panel in panels.items():
         method_index = _safe(panel.combo_method.currentIndex, 0)
+        optimizer_enabled = bool(_safe(
+            getattr(panel, "bt_use_optimize", None).isChecked, False
+        )) if getattr(panel, "bt_use_optimize", None) is not None else False
         for suffix, label, attr, unit, method in specs:
+            if suffix in {
+                "btrack.distance_threshold", "btrack.time_threshold",
+            } and not optimizer_enabled:
+                continue
             widget = getattr(panel, attr, None)
             if widget is None:
                 continue
@@ -360,12 +407,13 @@ def _tracking_bindings(main_widget) -> list[dict]:
                                 unit=unit, method=method, cell_type=str(cell_type),
                                 visible=visible, persist=getattr(panel, "_persist", None)))
         checks = getattr(panel, "bt_hyp_checks", {}) or {}
-        if checks:
+        if checks and optimizer_enabled:
             out.append(_checkset_binding(
                 f"tracking.{cell_type}.btrack.hypotheses",
                 f"{cell_type}: btrack optimization hypotheses", checks,
                 step="tracking", method="btrack", cell_type=str(cell_type),
-                visible=method_index == 3, persist=getattr(panel, "_persist", None),
+                visible=method_index == 3,
+                persist=getattr(panel, "_persist", None),
             ))
     return out
 
@@ -404,8 +452,8 @@ def _filter_bindings(main_widget) -> list[dict]:
         ("trim_to_maximum.timepoints", "Maximum timepoints", "spin_exp_duration", "timepoints"),
         ("minimum_length.enabled", "Filter short tracks", "en_min_length", None),
         ("minimum_length.timepoints", "Minimum track length", "spin_min_length", "timepoints"),
-        ("maximum_length.enabled", "Trim long tracks", "en_max_length", None),
-        ("maximum_length.timepoints", "Maximum track length", "spin_max_length", "timepoints"),
+        ("maximum_length.enabled", "Trim retained tracks to a common length", "en_max_length", None),
+        ("maximum_length.timepoints", "Common output track length", "spin_max_length", "timepoints"),
         ("minimum_initial_size.enabled", "Filter by initial size", "check_filter_min_size", None),
         ("minimum_initial_size.pixels", "Minimum initial size", "spin_min_size_t1", "pixels"),
         ("dead_at_first_timepoint.enabled", "Filter dead cells at first timepoint", "check_filter_dead_t0", None),

--- a/behav3d/napari/_assistant_recommendations.py
+++ b/behav3d/napari/_assistant_recommendations.py
@@ -120,8 +120,11 @@ def format_edt_recommendations(result: dict, cell_type: str) -> str:
     lines.extend([
         "",
         f"A practical global starting value is **{result['global_start_px']:g} pixels** "
-        "(the median middle candidate across samples). Lower EDT values split touching "
-        "objects more aggressively; higher values keep more objects merged.",
+        "(the median middle candidate across samples). On the plain Mask + EDT/Watershed "
+        "strategy, higher EDT values generally split touching objects more and lower values "
+        "keep neighbouring cores connected. On Peak EDT/Watershed, the direction is reversed "
+        "because EDT is used as a minimum peak-height filter. Probability Map + Watershed uses "
+        "Mask and Seed thresholds instead of EDT.",
         "",
         "These candidates are 20%, 25%, and 30% of the expected XY diameter. "
         "They are XY-based starting points, so preview segmentation around them before "

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -53,10 +53,16 @@ curl -N -X POST <url>/chat \
   -d '{"messages":[{"role":"user","content":"set the trackpy search range to 40 for immune"}],"context":{"current_step":"tracking"}}'
 ```
 
+Replay the PI feedback scenarios against the configured deployed endpoint:
+```bash
+conda run -n behav3d python chatbot/smoke_test.py
+```
+Use `--scenario merged_cell_thresholds` for one case or `--json-out /tmp/report.json`
+to retain the complete responses and tool calls.
+
 ## Refreshing the parameter schema
 `schema_cards.json` is generated from the live BEHAV3D config:
 ```bash
 conda run -n behav3d python -c "from behav3d.napari._assistant_schema import dump_cards_json; dump_cards_json('chatbot/schema_cards.json')"
 ```
 Re-run `python -m modal run chatbot/app.py::ingest` afterwards.
-

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -44,6 +44,147 @@ _TOOL_NAMES = (
     "summarize_track_counts",
 )
 _TOOL_NAME_PATTERN = "|".join(re.escape(name) for name in _TOOL_NAMES)
+CONTROL_CONTRACT_VERSION = "2.5"
+
+
+def tools_for_context(tools: list[dict], context: dict) -> list[dict]:
+    """Remove destructive setup tools once metadata or sample forms exist."""
+    metadata = context.get("metadata", {}) or {}
+    builder = context.get("metadata_builder", {}) or {}
+    controls = (context.get("ui_state", {}) or {}).get("controls", []) or []
+    has_sample_forms = any(
+        str(control.get("id") or "").startswith("metadata.samples.")
+        for control in controls
+    )
+    existing_metadata = bool(metadata.get("loaded")) or (
+        metadata.get("record_source") == "metadata_builder_draft"
+    )
+    if existing_metadata or (builder.get("open") and has_sample_forms):
+        return [tool for tool in tools if tool.get("name") != "bulk_fill_metadata"]
+    return list(tools)
+
+
+def should_force_bulk_metadata(context: dict, user_message: str, tools: list[dict]) -> bool:
+    """Require the bulk builder for a substantive new-experiment description."""
+    if not any(tool.get("name") == "bulk_fill_metadata" for tool in tools):
+        return False
+    metadata = context.get("metadata", {}) or {}
+    if metadata.get("loaded") or metadata.get("record_source") == "metadata_builder_draft":
+        return False
+    text = str(user_message or "").lower()
+    setup_intent = any(phrase in text for phrase in (
+        "set up", "setup", "build metadata", "create metadata", "fill metadata",
+    ))
+    sample_count = bool(re.search(
+        r"\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+"
+        r"(?:movies?|samples?|fields? of view|acquisitions?)\b",
+        text,
+    ))
+    fact_groups = [
+        ("pixel size", "resolution", "um/pixel", "µm/pixel"),
+        ("z spacing", "z-spacing", "z step", "optical sections"),
+        ("time-lapse", "time lapse", "time interval", "acquired every"),
+        ("channel", "ch0", "ch1", "ch2", "ch3"),
+        ("immune type", "cell type", "organoid", "collagen"),
+    ]
+    supplied_facts = sum(any(marker in text for marker in group) for group in fact_groups)
+    return setup_intent and sample_count and supplied_facts >= 2
+
+
+def model_tool_policy(force_bulk: bool, has_tools: bool) -> tuple[object, dict | None]:
+    """Return a DeepSeek-compatible tool choice and thinking override."""
+    if force_bulk:
+        # V4 intermittently rejects named tool_choice even when thinking is
+        # disabled. Supplying only the bulk tool plus the system contract keeps
+        # selection unambiguous without sending tool_choice at all.
+        return None, {"thinking": {"type": "disabled"}}
+    return ("auto" if has_tools else None), None
+
+
+def sanitize_bulk_metadata_arguments(arguments: dict, user_message: str) -> dict:
+    """Drop per-sample identifiers that were not actually supplied by the user."""
+    cleaned = json.loads(json.dumps(arguments or {}))
+    text = str(user_message or "").lower()
+    normalized_text = re.sub(r"[^a-z0-9]+", "", text)
+    uncertainty = any(phrase in text for phrase in (
+        "do not know", "don't know", "not sure", "unsure", "seconds or minutes",
+    ))
+
+    def was_supplied(value) -> bool:
+        normalized = re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+        return bool(normalized) and normalized in normalized_text
+
+    for sample in cleaned.get("samples") or []:
+        if not isinstance(sample, dict):
+            continue
+        for field in ("sample_name", "dimension_order", "raw_image_path", "well", "exp_nr"):
+            if field in sample and not was_supplied(sample[field]):
+                sample.pop(field, None)
+        if uncertainty:
+            sample.pop("time_unit", None)
+        elif "time_unit" in sample and not was_supplied(sample["time_unit"]):
+            sample.pop("time_unit", None)
+        cell_types = sample.get("cell_types")
+        if isinstance(cell_types, dict):
+            sample["cell_types"] = {
+                name: values for name, values in cell_types.items() if values
+            }
+            if not sample["cell_types"]:
+                sample.pop("cell_types", None)
+    return cleaned
+
+
+def recover_single_control_action(
+    calls: list[dict], context: dict, user_message: str, response_text: str,
+) -> list[dict]:
+    """Recover a missed confirmable edit when exactly one control can be targeted."""
+    if calls or not re.search(
+        r"\b(?:adjust|apply|change|correct|fill|fix|set|update)\b",
+        str(user_message or ""), re.IGNORECASE,
+    ):
+        return calls
+    controls = [
+        control for control in ((context.get("ui_state", {}) or {}).get("controls", []) or [])
+        if control.get("id") and control.get("visible") and control.get("enabled")
+    ]
+    if len(controls) != 1:
+        return calls
+    control = controls[0]
+    text = str(response_text or "")
+    value = None
+    choices = control.get("choices") or []
+    if choices:
+        matches = [
+            choice for choice in choices
+            if re.search(rf"\b{re.escape(str(choice))}\b", text, re.IGNORECASE)
+            and str(choice).lower() != str(control.get("value")).lower()
+        ]
+        if len(matches) == 1:
+            value = matches[0]
+    elif isinstance(control.get("value"), bool):
+        lowered = text.lower()
+        if any(word in lowered for word in ("enable", "turn on")):
+            value = True
+        elif any(word in lowered for word in ("disable", "turn off")):
+            value = False
+    else:
+        patterns = (
+            r"(?:set|change|adjust|update)[^\n.]{0,180}?\bto\s*\**(-?\d+(?:\.\d+)?)",
+            r"(?:->|→)\s*\**(-?\d+(?:\.\d+)?)",
+        )
+        candidates = []
+        for pattern in patterns:
+            candidates.extend(re.findall(pattern, text, re.IGNORECASE))
+        if candidates:
+            number = float(candidates[-1])
+            current = control.get("value")
+            value = int(number) if isinstance(current, int) and number.is_integer() else number
+    if value is None:
+        return calls
+    return [{
+        "name": "set_ui_value",
+        "arguments": {"control_id": control["id"], "value": value},
+    }]
 
 
 def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict]) -> str:
@@ -79,6 +220,20 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "- To edit a visible field, call set_ui_value with an exact id from LIVE CONTROLS. Never invent "
         "an id. Same-value requests are complete: acknowledge briefly and move to the next relevant "
         "decision without calling the tool again.\n"
+        "- An explicit request to fill, set, update, fix, or adjust available values is incomplete without "
+        "the matching tool calls in that same response. Apply known shared values to every relevant sample "
+        "or exact cell type; do not narrate an action you have not called.\n"
+        "- bulk_fill_metadata is only for creating a new builder before metadata or sample forms exist. Once "
+        "metadata is loaded or draft sample controls exist, use set_ui_value for the latest requested fields; "
+        "never rebuild the form from values mentioned earlier in the conversation.\n"
+        "- When metadata is not loaded and the user provides a multi-field experiment description, call "
+        "bulk_fill_metadata directly; that single action opens and builds the Metadata Builder, so do not "
+        "call fill_metadata_builder with open_builder first. Include "
+        "one sample object per described movie, populate every unambiguous count, cell-type name, and shared "
+        "acquisition value, and omit unknown fields. Calling only open_builder or waiting to collect every "
+        "field is a failure. Do not wait for an output directory or one ambiguous unit before preparing the "
+        "known metadata; ask one focused follow-up after proposing those values. Never infer a dimension "
+        "order, time unit, image path, sample name, or well that the user did not provide.\n"
         "- Use only controls matching the selected method and exact cell type. Do not apply a change to "
         "a broad cell category.\n"
         "- Navigation and read-only result/preview actions may happen immediately. Filling a blank field "
@@ -90,6 +245,29 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "- For EDT advice, use recommend_edt so the conversion comes from metadata. Use a 10 um cell "
         "diameter by default. For an organoid, first ask how many cell widths span its diameter. Treat "
         "the returned values as preview starting points, not ground truth.\n"
+        "- For touching objects that remain merged, read the active instance strategy before advising. With "
+        "Probability Map + Watershed, raise Mask threshold and Seed threshold in small increments and keep "
+        "Seed threshold at least as high as Mask threshold. With plain Mask + EDT/Watershed, raise EDT "
+        "threshold. With Peak EDT/Watershed, lower EDT threshold because that field is a peak-height filter. "
+        "Reverse the relevant direction for over-splitting, change only controls present in LIVE CONTROLS, "
+        "and ask the user to inspect a preview after each small change.\n"
+        "- Before recommending a tracking method, establish how much that exact structure moves between "
+        "consecutive frames; do not infer motion from a label such as immune, organoid, or collagen. If it "
+        "stays spatially overlapping from frame to frame, recommend Propagation. For visibly moving objects, "
+        "choose among LAP, TrackPy, and btrack based on density, gaps, crossings, and divisions.\n"
+        "- Before recommending a tracking distance, read Time interval and Time unit from every metadata "
+        "record. Convert any stated speed to displacement per frame; for example, 60 um/min at 15 seconds "
+        "per frame is 15 um/frame. Use the fastest plausible one-frame displacement plus a modest 10-25% "
+        "margin. Never invent a typical speed or recommend 50/100 um without motion evidence.\n"
+        "- When movement has not been quantified, ask for observed displacement and stop. Do not provide a "
+        "numeric example speed, a supposed typical range, or a numeric search radius.\n"
+        "- Ignore populated child values of disabled options. In particular, do not suggest enabling btrack "
+        "global optimization merely because its inherited thresholds contain defaults; discuss it only when "
+        "the user reports gaps, false links, merges, or divisions that require it.\n"
+        "- Minimum track length and common output track length may validly be equal: the minimum removes "
+        "shorter tracks and the maximum trims retained longer tracks to a comparable fixed window. Never call "
+        "that combination contradictory. Do not call a chosen minimum reasonable or recommended before reading "
+        "the track-length distribution and the user's downstream analysis; explain its effect neutrally.\n"
         "- For cell counts under minimum track-length filters or at a requested timepoint, always use "
         "summarize_track_counts. Never estimate counts or calculate them from prose.\n"
         "- Produce at most the actions needed for this one user turn. There is no hidden continuation turn."
@@ -365,7 +543,7 @@ if modal is not None:
         @api.get("/health")
         def health():
             return {"ok": True, "chunks": len(index.chunks), "model": deepseek_model,
-                    "control_contract_version": "2.0",
+                    "control_contract_version": CONTROL_CONTRACT_VERSION,
                     "knowledge_version": KNOWLEDGE_VERSION}
 
         @api.post("/chat")
@@ -373,10 +551,13 @@ if modal is not None:
             body = await request.json()
             messages = body.get("messages", [])
             context = body.get("context", {})
-            tools = body.get("tools", [])
+            tools = tools_for_context(body.get("tools", []), context)
 
             user_msg = next((m["content"] for m in reversed(messages)
                              if m.get("role") == "user"), "")
+            force_bulk = should_force_bulk_metadata(context, user_msg, tools)
+            if force_bulk:
+                tools = [tool for tool in tools if tool.get("name") == "bulk_fill_metadata"]
             query = f"{context.get('current_step','')} {user_msg}"
             try:
                 retrieved = index.search(embedder.encode([query])[0], k=6)
@@ -394,6 +575,9 @@ if modal is not None:
                            (context.get("ui_state", {}) or {}).get("controls", [])
                            if item.get("id") and item.get("enabled") and item.get("visible")]
             oai_tools = to_openai_tools(tools, key_enum=control_ids)
+            tool_choice, thinking_override = model_tool_policy(
+                force_bulk, bool(oai_tools)
+            )
 
             def sse(obj):
                 return "data: " + json.dumps(obj) + "\n\n"
@@ -402,11 +586,19 @@ if modal is not None:
                 content = ""
                 tool_frags = []
                 try:
+                    request_options = {
+                        "model": deepseek_model,
+                        "messages": convo,
+                        "tools": oai_tools or None,
+                        "temperature": 0.3,
+                        "stream": True,
+                    }
+                    if tool_choice is not None:
+                        request_options["tool_choice"] = tool_choice
+                    if thinking_override is not None:
+                        request_options["extra_body"] = thinking_override
                     stream = client.chat.completions.create(
-                        model=deepseek_model, messages=convo,
-                        tools=oai_tools or None,
-                        tool_choice="auto" if oai_tools else None,
-                        temperature=0.3, stream=True,
+                        **request_options
                     )
                     for chunk in stream:
                         delta = chunk.choices[0].delta
@@ -428,6 +620,15 @@ if modal is not None:
                 calls = assemble_tool_calls(tool_frags)
                 if not calls:                       # fallback: call embedded in text
                     _, calls = parse_tool_calls(content)
+                calls = recover_single_control_action(
+                    calls, context, user_msg, content
+                )
+                if force_bulk:
+                    for call in calls:
+                        if call.get("name") == "bulk_fill_metadata":
+                            call["arguments"] = sanitize_bulk_metadata_arguments(
+                                call.get("arguments", {}), user_msg
+                            )
                 if calls:
                     yield sse({"type": "tool_calls", "calls": calls})
                 yield sse({"type": "done"})

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-KNOWLEDGE_VERSION = "2026.07.14.2"
+KNOWLEDGE_VERSION = "2026.07.22.1"
 
 
 GUIDANCE_CARDS = {
@@ -11,6 +11,10 @@ GUIDANCE_CARDS = {
         "for a value. Never ask the user to repeat a value that is present. A folder of TIFFs is "
         "not one supported movie input: each sample needs one multidimensional image file or "
         "hyperstack. Valid 5D dimension orders are TCZYX, TZCYX, ZCTYX, ZTCYX, CZTYX, and CTZYX. "
+        "When a researcher describes several movies, cell types, and acquisition settings before "
+        "metadata exists, open the Metadata Builder and populate all known values immediately; omit "
+        "unknown fields and ask only for the one ambiguity that matters next. If asked to correct a "
+        "shared acquisition value, propose that correction for every sample rather than only Sample 1. "
         "When asked what analysis to run, first ask the research question; do not infer it from "
         "metadata alone."
     ),
@@ -21,18 +25,30 @@ GUIDANCE_CARDS = {
         "model when repeatable accuracy across experiments justifies model training. Import accepts "
         "existing TIFF or zarr segmentations. After a method is selected, discuss only controls whose "
         "method matches that selection. APOC is not the Random Forest pixel classifier. For EDT advice, "
-        "calculate the expected XY diameter from each sample's pixel_distance_xy. A 10 um cell is the "
+        "calculate the expected XY diameter from each sample's XY pixel size. A 10 um cell is the "
         "default reference. Try 20%, 25%, and 30% of the diameter in pixels as transparent preview "
-        "starting points. For organoids, first ask how many cell widths span the diameter."
+        "starting points. For organoids, first ask how many cell widths span the diameter. For merged "
+        "objects, the tuning direction depends on the active strategy: raise both mask and seed thresholds "
+        "for Probability Map + Watershed, keeping seed at least as high as mask; raise EDT for plain Mask + "
+        "EDT/Watershed; lower EDT for Peak EDT/Watershed, where EDT is a peak-height filter. Make small "
+        "changes and preview. Reverse the relevant direction when objects are over-split."
     ),
     "tracking": (
-        "Read the current values for the exact cell type before recommending changes. btrack maximum "
-        "search radius and optimizer distance threshold are physical distances after metadata scaling, "
-        "normally micrometres, not pixels. Use visual features adds image-derived measurements to "
-        "linking; global optimization is a separate second stage. Discuss P_branch only when global "
-        "optimization is already enabled and divisions matter. For customization, copy the bundled "
-        "cell_config.json and edit the copy. Describe tracking failures as hypotheses to check, not "
-        "certain diagnoses."
+        "Read the current values for the exact cell type before recommending changes. First establish "
+        "observed movement between consecutive frames; do not infer it from the cell-type label or category. "
+        "Use Propagation for structures that remain spatially overlapping from frame to frame. Use LAP, "
+        "TrackPy, or btrack for moving objects, choosing based on density, gaps, crossings, and divisions. "
+        "Before proposing a linking distance, read the metadata time interval and unit, convert any speed to "
+        "one-frame displacement, and add only a modest 10-25% margin. For example, 60 um/min sampled every "
+        "15 seconds is 15 um/frame, suggesting about 17-19 um rather than 50-100 um. When the user has not "
+        "supplied a speed or displacement, ask for it without offering a generic numeric example or a supposed "
+        "typical range. btrack maximum search "
+        "radius and optimizer distance threshold are physical distances after metadata scaling, normally "
+        "micrometres, not pixels. Enabling visual features adds image-derived measurements to linking; global "
+        "optimization is a separate second stage. Ignore inherited optimizer values while optimization is "
+        "disabled. Discuss P_branch only when optimization is enabled and divisions matter. For customization, "
+        "copy the bundled cell_config.json and edit the copy. Describe tracking failures as hypotheses to "
+        "check, not certain diagnoses."
     ),
     "feature_extraction": (
         "Cell-type grouping is available in Feature Extraction and creates a merged metadata type; "
@@ -43,8 +59,12 @@ GUIDANCE_CARDS = {
     "filtering": (
         "Use the track-length distribution preview before choosing a minimum length. A higher minimum "
         "removes short unreliable tracks but can exclude real short-lived behavior. Visual accuracy and "
-        "the downstream analysis matter more than forcing equal track lengths. Trim to equal lengths only "
-        "when the selected downstream workflow requires comparable windows. For count questions, use "
+        "the downstream analysis determine whether a particular threshold is reasonable; do not endorse a "
+        "numeric minimum before reading the distribution. They matter more than forcing equal track lengths. "
+        "Trim to equal lengths only "
+        "when the selected downstream workflow requires comparable windows. Equal minimum and maximum "
+        "lengths are valid, not contradictory: the minimum discards shorter tracks, then the maximum trims "
+        "retained longer tracks to the same comparison window. For count questions, use "
         "the unfiltered combined track-features CSV. Track length is the number of unique position_t "
         "values per sample and TrackID. Count only qualifying tracks that are present at the requested "
         "position_t; never estimate the result."
@@ -71,8 +91,14 @@ def select_guidance_cards(context: dict, user_message: str = "", intent: str | N
         selected.append(step)
     keyword_map = {
         "metadata": ("metadata", "sample", "dimension", "image path", "tiff", "voxel"),
-        "segmentation": ("segment", "apoc", "convpaint", "cellpose", "random forest", "edt"),
-        "tracking": ("track", "btrack", "branch", "visual feature", "search radius"),
+        "segmentation": (
+            "segment", "apoc", "convpaint", "cellpose", "random forest", "edt",
+            "mask threshold", "seed threshold", "touching", "split",
+        ),
+        "tracking": (
+            "track", "btrack", "branch", "visual feature", "search radius",
+            "propagation", "collagen", "movement", "motion",
+        ),
         "feature_extraction": ("feature", "group", "death", "dead threshold", "preview"),
         "filtering": ("filter", "track length", "short track", "distribution", "cell count", "timepoint"),
         "analysis": ("analysis", "hmm", "dtw", "state", "cluster", "log", "heatmap"),

--- a/chatbot/smoke_test.py
+++ b/chatbot/smoke_test.py
@@ -1,0 +1,471 @@
+"""Replay PI feedback scenarios against a deployed BEHAV3D Assistant API."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from behav3d.napari._assistant_actions import TOOL_SCHEMA
+
+
+DATASET_DESCRIPTION = (
+    "I have an intravital imaging dataset of a popliteal lymph node and want to set "
+    "up a BEHAV3D analysis. I have three movies, 2 immune types and 1 other type, "
+    "collagen. CH1 is T cells labelled with CMTMR, CH2 is HIV-GFP-infected T cells, "
+    "and CH3 is collagen. Z spacing is 4 um, XY pixel size is 1.15 um, and time-lapses "
+    "were acquired every 15, but I do not know whether that was seconds or minutes. "
+    "Help me set up the analysis. Where should I start?"
+)
+
+
+def _control(
+    control_id: str,
+    label: str,
+    value: Any,
+    *,
+    choices: list[str] | None = None,
+    method: str | None = None,
+    strategy: str | None = None,
+    cell_type: str | None = None,
+    unit: str | None = None,
+) -> dict:
+    return {
+        "id": control_id,
+        "label": label,
+        "value": value,
+        "choices": choices,
+        "visible": True,
+        "enabled": True,
+        "method": method,
+        "strategy": strategy,
+        "cell_type": cell_type,
+        "unit": unit,
+    }
+
+
+def _metadata_records() -> list[dict]:
+    return [
+        {
+            "sample_name": f"Movie{i}",
+            "pixel_distance_xy": 1.15,
+            "pixel_distance_z": 4.0,
+            "time_interval": 15,
+            "time_unit": "s",
+        }
+        for i in range(1, 4)
+    ]
+
+
+def _context(step: str, controls: list[dict], **extra) -> dict:
+    context = {
+        "current_step": step,
+        "current_tab_label": step.replace("_", " ").title(),
+        "assistant_session": {"intent": "free_form"},
+        "ui_state": {"controls": controls},
+        "metadata": {"loaded": True, "records": _metadata_records(), "validation": []},
+    }
+    context.update(extra)
+    return context
+
+
+def _metadata_setup_case() -> dict:
+    return {
+        "name": "metadata_setup",
+        "messages": [{"role": "user", "content": DATASET_DESCRIPTION}],
+        "context": _context(
+            "data_preparation", [],
+            metadata={"loaded": False, "records": [], "validation": []},
+            metadata_builder={"open": False, "n_samples": 1},
+        ),
+        "check": _check_metadata_setup,
+    }
+
+
+def _pixel_fill_case() -> dict:
+    controls = []
+    records = []
+    for index in range(3):
+        records.append({
+            "sample_name": f"Movie{index + 1}",
+            "pixel_distance_xy": 0.5,
+            "pixel_distance_z": 2.0,
+            "time_interval": 15,
+            "time_unit": "s",
+        })
+        controls.extend([
+            _control(
+                f"metadata.samples.{index}.pixel_distance_xy",
+                f"Sample {index + 1}: XY pixel size", 0.5, unit="um",
+            ),
+            _control(
+                f"metadata.samples.{index}.pixel_distance_z",
+                f"Sample {index + 1}: Z pixel size", 2.0, unit="um",
+            ),
+        ])
+    return {
+        "name": "fill_pixel_sizes",
+        "messages": [
+            {"role": "user", "content": DATASET_DESCRIPTION},
+            {"role": "assistant", "content": "I can help prepare the metadata."},
+            {"role": "user", "content": "Can you fill in the correct pixel size?"},
+        ],
+        "context": _context(
+            "data_preparation", controls,
+            metadata={
+                "loaded": True,
+                "record_source": "metadata_builder_draft",
+                "records": records,
+                "validation": [],
+                "save_required": True,
+            },
+            metadata_builder={"open": True, "n_samples": 3},
+        ),
+        "check": _check_pixel_fill,
+    }
+
+
+def _segmentation_case() -> dict:
+    strategy = "APOC Probability Map + Watershed"
+    controls = [
+        _control(
+            "segmentation.apoc.Tcell_cmtrm.mask_threshold",
+            "Tcell cmtrm: APOC mask threshold", 0.4,
+            method="APOC", strategy=strategy, cell_type="Tcell_cmtrm",
+        ),
+        _control(
+            "segmentation.apoc.Tcell_cmtrm.seed_threshold",
+            "Tcell cmtrm: APOC seed threshold", 0.7,
+            method="APOC", strategy=strategy, cell_type="Tcell_cmtrm",
+        ),
+    ]
+    return {
+        "name": "merged_cell_thresholds",
+        "messages": [{
+            "role": "user",
+            "content": "I see a lot of cells that are not split in the T cell CMTMR channel.",
+        }],
+        "context": _context(
+            "segmentation", controls,
+            active_cell_type="Tcell_cmtrm",
+            segmentation={
+                "method": "APOC (GPU)",
+                "apoc": {"cell_type_strategies": {"Tcell_cmtrm": strategy}},
+            },
+        ),
+        "check": _check_segmentation,
+    }
+
+
+def _tracking_guide_case() -> dict:
+    choices = ["LAP (laptrack)", "TrackPy", "Propagation", "btrack (Bayesian)"]
+    controls = [
+        _control(
+            f"tracking.{cell_type}.method", f"{cell_type}: Tracking method", method,
+            choices=choices, cell_type=cell_type,
+        )
+        for cell_type, method in (
+            ("Tcell_HIV", "btrack (Bayesian)"),
+            ("Tcell_cmtrm", "btrack (Bayesian)"),
+            ("collagen", "LAP (laptrack)"),
+        )
+    ]
+    return {
+        "name": "tracking_asks_about_motion",
+        "messages": [{"role": "user", "content": "Guide tracking"}],
+        "context": _context("tracking", controls, active_cell_type="Tcell_HIV"),
+        "check": _check_tracking_guide,
+    }
+
+
+def _stationary_tracking_case() -> dict:
+    controls = [_control(
+        "tracking.collagen.method", "collagen: Tracking method", "LAP (laptrack)",
+        choices=["LAP (laptrack)", "TrackPy", "Propagation", "btrack (Bayesian)"],
+        cell_type="collagen",
+    )]
+    return {
+        "name": "stationary_uses_propagation",
+        "messages": [
+            {"role": "user", "content": "Guide tracking"},
+            {"role": "assistant", "content": "How much does collagen move between frames?"},
+            {"role": "user", "content": "Collagen stays stationary and overlaps between frames."},
+        ],
+        "context": _context("tracking", controls, active_cell_type="collagen"),
+        "check": _check_stationary_tracking,
+    }
+
+
+def _tracking_radius_case() -> dict:
+    controls = [_control(
+        "tracking.Tcell_cmtrm.btrack.maximum_search_radius",
+        "Tcell cmtrm: btrack maximum search radius", 100,
+        method="btrack", cell_type="Tcell_cmtrm", unit="um",
+    )]
+    return {
+        "name": "tracking_radius_uses_interval",
+        "messages": [{
+            "role": "user",
+            "content": (
+                "The fastest Tcell_cmtrm cells move about 60 um per minute. "
+                "Please adjust their maximum search radius for our 15 second interval."
+            ),
+        }],
+        "context": _context("tracking", controls, active_cell_type="Tcell_cmtrm"),
+        "check": _check_tracking_radius,
+    }
+
+
+def _filtering_case() -> dict:
+    controls = [
+        _control("filtering.Tcell_HIV.minimum_length.enabled", "Filter short tracks", True),
+        _control(
+            "filtering.Tcell_HIV.minimum_length.timepoints",
+            "Minimum track length", 30, unit="timepoints",
+        ),
+        _control(
+            "filtering.Tcell_HIV.maximum_length.enabled",
+            "Trim retained tracks to a common length", True,
+        ),
+        _control(
+            "filtering.Tcell_HIV.maximum_length.timepoints",
+            "Common output track length", 30, unit="timepoints",
+        ),
+    ]
+    return {
+        "name": "equal_track_lengths_are_valid",
+        "messages": [{"role": "user", "content": "Review filters"}],
+        "context": _context("filtering", controls, active_cell_type="Tcell_HIV"),
+        "check": _check_filtering,
+    }
+
+
+def _tool_calls(result: dict, name: str) -> list[dict]:
+    return [call.get("arguments", {}) for call in result["calls"] if call.get("name") == name]
+
+
+def _check_metadata_setup(result: dict) -> list[str]:
+    errors = []
+    bulk = _tool_calls(result, "bulk_fill_metadata")
+    if not bulk:
+        return errors + ["did not propose bulk metadata population"]
+    args = bulk[0]
+    expected = {"n_samples": 3, "n_immune": 2, "n_other": 1}
+    for key, value in expected.items():
+        if args.get(key) != value:
+            errors.append(f"{key} was {args.get(key)!r}, expected {value}")
+    samples = args.get("samples") or []
+    if len(samples) != 3:
+        errors.append(f"created {len(samples)} sample objects instead of 3")
+    for index, sample in enumerate(samples):
+        for key, value in (("pixel_distance_xy", 1.15), ("pixel_distance_z", 4)):
+            if sample.get(key) != value:
+                errors.append(f"sample {index + 1} {key} was not populated with {value}")
+        if sample.get("time_interval") not in (None, 15):
+            errors.append(
+                f"sample {index + 1} time_interval was "
+                f"{sample.get('time_interval')!r}, expected 15 or blank"
+            )
+        for unknown in ("dimension_order", "time_unit", "raw_image_path", "sample_name", "well"):
+            if sample.get(unknown) not in (None, ""):
+                errors.append(f"sample {index + 1} invented {unknown}={sample.get(unknown)!r}")
+    immune_names = [str(item).lower() for item in (args.get("immune_names") or [])]
+    other_names = [str(item).lower() for item in (args.get("other_names") or [])]
+    if len(immune_names) != 2:
+        errors.append(f"created {len(immune_names)} immune names instead of 2")
+    if not any("hiv" in name and ("t" in name or "cell" in name) for name in immune_names):
+        errors.append("immune names did not include an HIV-specific T-cell population")
+    if not any(
+        ("cmtmr" in name) or ("t" in name and "hiv" not in name)
+        for name in immune_names
+    ):
+        errors.append("immune names did not include the uninfected T-cell population")
+    if not any("collagen" in name for name in other_names):
+        errors.append("other cell-type names did not include collagen")
+    return errors
+
+
+def _check_pixel_fill(result: dict) -> list[str]:
+    calls = _tool_calls(result, "set_ui_value")
+    changed = {call.get("control_id"): call.get("value") for call in calls}
+    errors = []
+    for index in range(3):
+        expected = {
+            f"metadata.samples.{index}.pixel_distance_xy": 1.15,
+            f"metadata.samples.{index}.pixel_distance_z": 4,
+        }
+        for control_id, value in expected.items():
+            if changed.get(control_id) != value:
+                errors.append(f"missing {control_id} -> {value}")
+    return errors
+
+
+def _check_segmentation(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    bad_directions = (
+        "lower the mask", "lower mask", "decrease the mask", "decrease mask",
+        "lower the seed", "lower seed", "decrease the seed", "decrease seed",
+    )
+    if any(phrase in text for phrase in bad_directions):
+        errors.append("response still recommends lowering Mask or Seed threshold")
+    calls = _tool_calls(result, "set_ui_value")
+    values = {call.get("control_id"): call.get("value") for call in calls}
+    mask = values.get("segmentation.apoc.Tcell_cmtrm.mask_threshold")
+    seed = values.get("segmentation.apoc.Tcell_cmtrm.seed_threshold")
+    if mask is not None and float(mask) <= 0.4:
+        errors.append(f"Mask threshold action did not increase the value: {mask}")
+    if seed is not None and float(seed) <= 0.7:
+        errors.append(f"Seed threshold action did not increase the value: {seed}")
+    if not calls and not any(word in text for word in ("raise", "increase", "higher")):
+        errors.append("response does not advise increasing the active thresholds")
+    return errors
+
+
+def _check_tracking_guide(result: dict) -> list[str]:
+    text = result["text"].lower()
+    asks_motion = any(word in text for word in ("move", "motion", "displacement", "overlap"))
+    asks_question = "?" in result["text"] or "how much" in text
+    errors = []
+    if not (asks_motion and asks_question):
+        errors.append("did not ask about frame-to-frame motion before choosing methods")
+    if result["calls"]:
+        errors.append("changed tracking settings before learning how structures move")
+    if any(token in text for token in ("um/min", "µm/min", "micrometres per minute")):
+        errors.append("invented a numeric example speed before the user quantified movement")
+    return errors
+
+
+def _check_stationary_tracking(result: dict) -> list[str]:
+    text = result["text"].lower()
+    method_calls = _tool_calls(result, "set_ui_value")
+    proposed = any(
+        call.get("control_id") == "tracking.collagen.method"
+        and str(call.get("value", "")).lower().startswith("propagation")
+        for call in method_calls
+    )
+    if "propagation" not in text and not proposed:
+        return ["did not recommend Propagation for stationary collagen"]
+    return []
+
+
+def _check_tracking_radius(result: dict) -> list[str]:
+    calls = _tool_calls(result, "set_ui_value")
+    match = next((
+        call for call in calls
+        if call.get("control_id") == "tracking.Tcell_cmtrm.btrack.maximum_search_radius"
+    ), None)
+    if match is None:
+        return ["did not propose a maximum search-radius action"]
+    try:
+        value = float(match.get("value"))
+    except (TypeError, ValueError):
+        return [f"search radius was not numeric: {match.get('value')!r}"]
+    if not 16.5 <= value <= 19:
+        return [f"search radius was {value:g} um; expected 16.5-19 um from 15 um/frame plus margin"]
+    return []
+
+
+def _check_filtering(result: dict) -> list[str]:
+    text = result["text"].lower()
+    if any(phrase in text for phrase in (
+        "are contradictory", "is contradictory", "settings conflict",
+        "are conflicting", "is incompatible",
+    )):
+        return ["described equal minimum and maximum track lengths as a conflict"]
+    if not any(word in text for word in ("same length", "equal length", "common length", "comparable")):
+        return ["did not explain the fixed-length comparison workflow"]
+    if "reasonable threshold" in text or "reasonable minimum" in text:
+        return ["endorsed the minimum before reading the track-length distribution"]
+    return []
+
+
+SCENARIOS = [
+    _metadata_setup_case,
+    _pixel_fill_case,
+    _segmentation_case,
+    _tracking_guide_case,
+    _stationary_tracking_case,
+    _tracking_radius_case,
+    _filtering_case,
+]
+
+
+def _default_endpoint() -> str:
+    endpoint = os.environ.get("BEHAV3D_ASSISTANT_ENDPOINT", "")
+    if endpoint:
+        return endpoint.rstrip("/")
+    config = Path(__file__).parents[1] / "napari" / "assistant_config.json"
+    if config.exists():
+        return str(json.loads(config.read_text(encoding="utf-8")).get("endpoint", "")).rstrip("/")
+    return ""
+
+
+def _request(endpoint: str, case: dict, timeout: int) -> dict:
+    response = requests.post(
+        f"{endpoint}/chat",
+        json={"messages": case["messages"], "context": case["context"], "tools": TOOL_SCHEMA},
+        headers={"Content-Type": "application/json"},
+        stream=True,
+        timeout=(10, timeout),
+    )
+    response.raise_for_status()
+    text_parts: list[str] = []
+    calls: list[dict] = []
+    for raw in response.iter_lines(decode_unicode=True):
+        if not raw:
+            continue
+        line = raw[6:] if raw.startswith("data: ") else raw
+        event = json.loads(line)
+        if event.get("type") == "token":
+            text_parts.append(event.get("text", ""))
+        elif event.get("type") == "tool_calls":
+            calls.extend(event.get("calls") or [])
+        elif event.get("type") == "error":
+            raise RuntimeError(event.get("message") or "Unknown assistant API error")
+    return {"text": "".join(text_parts).strip(), "calls": calls}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", default=_default_endpoint())
+    parser.add_argument("--timeout", type=int, default=90)
+    parser.add_argument(
+        "--scenario", action="append",
+        choices=[factory()["name"] for factory in SCENARIOS],
+        help="Run only this scenario; repeat to select several.",
+    )
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+    if not args.endpoint:
+        parser.error("Provide --endpoint or configure BEHAV3D_ASSISTANT_ENDPOINT")
+
+    selected = [factory() for factory in SCENARIOS]
+    if args.scenario:
+        selected = [case for case in selected if case["name"] in args.scenario]
+
+    report = []
+    for case in selected:
+        print(f"\n=== {case['name']} ===", flush=True)
+        try:
+            result = _request(args.endpoint, case, args.timeout)
+            errors = case["check"](result)
+        except Exception as exc:
+            result, errors = {"text": "", "calls": []}, [str(exc)]
+        report.append({"scenario": case["name"], **result, "errors": errors})
+        print(result["text"] or "(no visible text)")
+        print("Tool calls:", json.dumps(result["calls"], indent=2, ensure_ascii=False))
+        print("PASS" if not errors else "FAIL: " + "; ".join(errors))
+
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    failures = sum(bool(item["errors"]) for item in report)
+    print(f"\n{len(report) - failures}/{len(report)} scenarios passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/fixtures/assistant_feedback_transcripts.json
+++ b/test/fixtures/assistant_feedback_transcripts.json
@@ -40,12 +40,30 @@
     "id": "metadata_based_edt",
     "step": "segmentation",
     "user": "Calcula el EDT segun la resolucion de mis imagenes.",
-    "required": ["10 um cell", "pixel_distance_xy", "20%, 25%, and 30%", "cell widths"]
+    "required": ["10 um cell", "XY pixel size", "20%, 25%, and 30%", "cell widths"]
   },
   {
     "id": "interactive_track_counts",
     "step": "filtering",
     "user": "Si filtro a 200 timepoints, cuantos tracks quedan en position_t 0?",
     "required": ["unique position_t", "requested position_t", "never estimate"]
+  },
+  {
+    "id": "merged_cells_threshold_direction",
+    "step": "segmentation",
+    "user": "The CMTMR T cells are touching and not split.",
+    "required": ["raise both mask and seed thresholds", "raise EDT for plain", "lower EDT for Peak"]
+  },
+  {
+    "id": "tracking_uses_motion_and_interval",
+    "step": "tracking",
+    "user": "Guide tracking for my T cells and collagen.",
+    "required": ["do not infer it from the cell-type label", "Use Propagation", "one-frame displacement", "15 seconds is 15 um/frame"]
+  },
+  {
+    "id": "equal_track_lengths_are_valid",
+    "step": "filtering",
+    "user": "Are minimum 30 and maximum 30 contradictory?",
+    "required": ["valid, not contradictory", "trims retained longer tracks", "same comparison window"]
   }
 ]

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -238,6 +238,7 @@ def test_dump_cards_json(tmp_path=None):
 # --------------------------------------------------------------------------
 def test_app_tool_call_parsing_and_prompt():
     import app
+    assert app.CONTROL_CONTRACT_VERSION == CONTROL_CONTRACT_VERSION
     txt = ('try 2 channels.\n<TOOLCALL>{"name":"set_ui_value",'
            '"arguments":{"control_id":"segmentation.cellpose.number_of_channels",'
            '"value":2}}</TOOLCALL>')
@@ -250,6 +251,79 @@ def test_app_tool_call_parsing_and_prompt():
         [{"title": "btrack", "text": "good for crowded cells"}], [])
     assert "BEHAV3D" in sp and "good for crowded cells" in sp
     assert "at most the actions needed for this one user turn" in sp
+
+
+def test_backend_hides_bulk_metadata_tool_after_forms_exist():
+    import app
+    tools = [
+        {"name": "set_ui_value"},
+        {"name": "bulk_fill_metadata"},
+        {"name": "fill_metadata_builder"},
+    ]
+    fresh = app.tools_for_context(tools, {"metadata": {"loaded": False}})
+    assert {tool["name"] for tool in fresh} == {
+        "set_ui_value", "bulk_fill_metadata", "fill_metadata_builder",
+    }
+    existing = app.tools_for_context(tools, {
+        "metadata": {"loaded": True, "record_source": "metadata_builder_draft"},
+        "metadata_builder": {"open": True},
+        "ui_state": {"controls": [{"id": "metadata.samples.0.pixel_distance_xy"}]},
+    })
+    assert {tool["name"] for tool in existing} == {
+        "set_ui_value", "fill_metadata_builder",
+    }
+    description = (
+        "I have three movies with two immune cell types and collagen, four channels, "
+        "1.15 um pixel size and 4 um z spacing. Help me set up the analysis."
+    )
+    assert app.should_force_bulk_metadata(
+        {"metadata": {"loaded": False}}, description, fresh,
+    )
+    assert not app.should_force_bulk_metadata(
+        {"metadata": {"loaded": True}}, description, existing,
+    )
+    assert not app.should_force_bulk_metadata(
+        {"metadata": {"loaded": False}}, "What is metadata?", fresh,
+    )
+    forced_choice, forced_extra = app.model_tool_policy(True, True)
+    assert forced_choice is None
+    assert forced_extra == {"thinking": {"type": "disabled"}}
+    assert app.model_tool_policy(False, True) == ("auto", None)
+    assert app.model_tool_policy(False, False) == (None, None)
+    sanitized = app.sanitize_bulk_metadata_arguments({"samples": [{
+        "sample_name": "Movie_1", "dimension_order": "TCZYX",
+        "pixel_distance_xy": 1.15, "pixel_distance_z": 4,
+        "time_interval": 15, "time_unit": "s",
+        "cell_types": {"T cells": {}},
+    }]}, "I have three movies sampled every 15, but I do not know the unit")
+    assert sanitized == {"samples": [{
+        "pixel_distance_xy": 1.15, "pixel_distance_z": 4, "time_interval": 15,
+    }]}
+    recovered = app.recover_single_control_action(
+        [],
+        {"ui_state": {"controls": [{
+            "id": "tracking.tcell.btrack.maximum_search_radius",
+            "label": "Maximum search radius", "value": 100,
+            "visible": True, "enabled": True,
+        }]}},
+        "Please adjust the maximum search radius.",
+        "Would you like me to set the maximum search radius to **18 um**?",
+    )
+    assert recovered == [{
+        "name": "set_ui_value",
+        "arguments": {
+            "control_id": "tracking.tcell.btrack.maximum_search_radius", "value": 18,
+        },
+    }]
+    ambiguous = app.recover_single_control_action(
+        [],
+        {"ui_state": {"controls": [
+            {"id": "one", "value": 1, "visible": True, "enabled": True},
+            {"id": "two", "value": 2, "visible": True, "enabled": True},
+        ]}},
+        "Please adjust these.", "Set both to 3.",
+    )
+    assert ambiguous == []
 
 
 def test_tool_call_parsing_tolerates_malformed_markers():
@@ -415,6 +489,31 @@ def test_prompt_treats_metadata_builder_draft_as_current():
     assert "draft changes still need to be saved" in sp
 
 
+def test_prompt_encodes_pi_feedback_scenarios():
+    import app
+    sp = app.build_system_prompt(
+        {"current_step": "tracking", "metadata": {
+            "loaded": True,
+            "records": [{"sample_name": "Movie1", "time_interval": 15,
+                         "time_unit": "s"}],
+        }, "ui_state": {"controls": []}},
+        [], [])
+    assert "call bulk_fill_metadata directly" in sp
+    assert "Calling only open_builder" in sp
+    assert "Never infer a dimension order" in sp
+    assert "never rebuild the form from values mentioned earlier" in sp
+    assert "explicit request to fill, set, update, fix, or adjust" in sp
+    assert "raise Mask threshold and Seed threshold" in sp
+    assert "With plain Mask + EDT/Watershed, raise EDT" in sp
+    assert "With Peak EDT/Watershed, lower EDT" in sp
+    assert "do not infer motion from a label" in sp
+    assert "60 um/min at 15 seconds per frame is 15 um/frame" in sp
+    assert "Do not provide a numeric example speed" in sp
+    assert "merely because its inherited thresholds contain defaults" in sp
+    assert "Never call that combination contradictory" in sp
+    assert "Do not call a chosen minimum reasonable" in sp
+
+
 class _FakeSpin:
     def __init__(self, value, minimum=0, maximum=9999):
         self._value = value
@@ -487,6 +586,8 @@ class _FakeTrackingPanel:
         self.bt_max_search_radius = _FakeSpin(radius, 1, 9999)
         self.bt_use_visual_features = _FakeCheck(False)
         self.bt_use_optimize = _FakeCheck(False)
+        self.bt_dist_thresh = _FakeSpin(40.0)
+        self.bt_time_thresh = _FakeSpin(5)
         self.bt_hyp_checks = {"P_FP": _FakeCheck(True), "P_branch": _FakeCheck(False)}
         self.persisted = 0
 
@@ -497,6 +598,7 @@ def test_live_control_registry_targets_actual_cell_type_only():
     from types import SimpleNamespace
     tcell = _FakeTrackingPanel("tcell", 100)
     organoid = _FakeTrackingPanel("organoid1", 200)
+    organoid.bt_use_optimize.setChecked(True)
     tracking = SimpleNamespace(
         panels={"tcell": tcell, "organoid1": organoid},
         cell_tabs=_FakeTabs(tcell),
@@ -508,6 +610,12 @@ def test_live_control_registry_targets_actual_cell_type_only():
     assert "tracking.organoid1.btrack.maximum_search_radius" in ids
     assert "tracking.tcell.lap.merging_distance" in ids
     assert "tracking.tcell.trackpy.adaptive_step" in ids
+    by_id = {item["id"]: item for item in controls}
+    assert by_id["tracking.tcell.btrack.use_global_optimization"]["visible"] is True
+    assert "tracking.tcell.btrack.distance_threshold" not in by_id
+    assert "tracking.tcell.btrack.hypotheses" not in by_id
+    assert by_id["tracking.organoid1.btrack.distance_threshold"]["visible"] is True
+    assert by_id["tracking.organoid1.btrack.hypotheses"]["visible"] is True
     assert active_cell_type(main, "tracking") == "tcell"
     assert apply_set_ui_value(main, "tracking.tcell.btrack.maximum_search_radius", 125)
     assert tcell.bt_max_search_radius.value() == 125
@@ -659,6 +767,12 @@ def test_live_registry_covers_filtering_and_hmm_controls():
     assert "filtering.tcell.minimum_initial_size.enabled" in controls
     assert "filtering.tcell.dead_at_first_timepoint.enabled" in controls
     assert "filtering.tcell.time_unit" in controls
+    assert controls["filtering.tcell.maximum_length.enabled"]["label"].endswith(
+        "Trim retained tracks to a common length"
+    )
+    assert controls["filtering.tcell.maximum_length.timepoints"]["label"].endswith(
+        "Common output track length"
+    )
     states = "analysis.state_classification.tcell.number_of_states"
     assert states in controls and controls[states]["value"] == 4
     assert controls[states]["visible"] is True
@@ -677,6 +791,9 @@ def test_edt_recommendations_use_per_sample_xy_resolution():
     assert result["rows"][1]["edt_candidates_px"] == [2, 2.5, 3]
     text = format_edt_recommendations(result, "tcell")
     assert "Well_A1" in text and "global starting value" in text
+    assert "higher EDT values generally split touching objects more" in text
+    assert "On Peak EDT/Watershed, the direction is reversed" in text
+    assert "Lower EDT values split touching objects more aggressively" not in text
 
     organoid = calculate_edt_recommendations(
         [{"sample_name": "Org", "pixel_distance_xy": 0.5,
@@ -718,6 +835,48 @@ def test_segmentation_registry_exposes_exact_edt_control():
     assert control_id in controls and controls[control_id]["visible"] is True
     assert apply_set_ui_value(main, control_id, 5.0)
     assert edt.value() == 5.0
+
+
+def test_segmentation_registry_exposes_probability_thresholds_and_strategy():
+    from types import SimpleNamespace
+    persisted = []
+    strategy = _FakeCombo([
+        "APOC Probability Map + Watershed",
+        "APOC Mask + EDT/Watershed Resegmentation",
+    ])
+    tab = SimpleNamespace(
+        _per_tab_strategy_combo=strategy,
+        prob_mask_threshold_spin=_FakeSpin(0.4, 0.0, 1.0),
+        prob_seed_threshold_spin=_FakeSpin(0.7, 0.0, 1.0),
+        edt_threshold_spin=None,
+    )
+    training = SimpleNamespace(tabs={"Tcell_cmtrm": tab}, strategy_combo=None)
+    apoc = SimpleNamespace(
+        spin_examples=_FakeSpin(3), _training_widget=training,
+        _collect_apoc_tab_config=lambda: {"ok": True},
+        _save_apoc_params_to_yaml=lambda **kwargs: persisted.append(kwargs),
+    )
+    segmentation = SimpleNamespace(
+        method_combo=_FakeCombo([
+            "APOC (GPU)", "ConvPaint", "Pixel Classifier (Random Forest)",
+            "Cellpose", "Import segmentation",
+        ], 0),
+        apoc_page=apoc,
+        convpaint_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        pixel_classifier_page=SimpleNamespace(spin_examples=_FakeSpin(3)),
+        cellpose_page=SimpleNamespace(),
+    )
+    main = SimpleNamespace(segmentation_tab=segmentation)
+    controls = {item["id"]: item for item in control_registry(main)}
+    base = "segmentation.apoc.Tcell_cmtrm"
+    assert controls[f"{base}.mask_threshold"]["strategy"] == strategy.currentText()
+    assert controls[f"{base}.seed_threshold"]["value"] == 0.7
+    assert f"{base}.edt_threshold" not in controls
+    assert apply_set_ui_value(main, f"{base}.mask_threshold", 0.45)
+    assert apply_set_ui_value(main, f"{base}.seed_threshold", 0.75)
+    assert tab.prob_mask_threshold_spin.value() == 0.45
+    assert tab.prob_seed_threshold_spin.value() == 0.75
+    assert len(persisted) == 2
 
 
 def test_active_segmentation_cell_type_uses_method_subtab():
@@ -807,7 +966,7 @@ def test_feedback_guidance_fixtures():
 
     fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
     cases = json.loads(fixture.read_text(encoding="utf-8"))
-    assert KNOWLEDGE_VERSION == "2026.07.14.2"
+    assert KNOWLEDGE_VERSION == "2026.07.22.1"
     for case in cases:
         cards = select_guidance_cards(
             {"current_step": case["step"]}, case["user"], case.get("intent"))
@@ -824,7 +983,7 @@ def test_assistant_has_no_hidden_model_continuation():
     assert "def _auto_continue" not in source
     assert "_dispatch_proactive" not in source
     assert "Checking your setup" not in source
-    assert CONTROL_CONTRACT_VERSION == "2.0"
+    assert CONTROL_CONTRACT_VERSION == "2.5"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Make metadata setup actionable in one bulk operation while preserving unknown values and preventing accidental form resets.
- Expose active APOC and ConvPaint instance-segmentation strategies and their dynamic threshold controls.
- Correct strategy-specific segmentation guidance for merged and over-split objects.
- Ground tracking recommendations in observed movement and metadata time intervals, and prefer Propagation for overlapping stationary structures.
- Clarify fixed-length filtering behavior and hide inactive btrack optimizer controls.
- Recover explicit single-field edits when the model explains a value but omits the corresponding UI action.
- Add a reusable deployed-API smoke harness based on the PI feedback scenarios.

## Root Cause

The assistant could see broad workflow context but did not always receive the exact dynamic controls needed for an action. In other cases, the model described a valid change without emitting a tool call or reused setup tools after metadata forms already existed. The guidance also lacked method-specific distinctions for segmentation, movement-first tracking decisions, and equal-length filtering.

## User Impact

Researchers can now describe an experiment and have known metadata populated directly, receive advice using researcher-facing labels and current acquisition values, and apply recommended edits through confirmable UI actions. Dynamic segmentation, tracking, and filtering guidance is tied to the visible method and state instead of generic defaults.

## Validation

- 42/42 assistant logic tests passed.
- Python compilation passed for all changed modules and the smoke harness.
- Deployed Modal API contract 2.5 passed all 7/7 PI-feedback scenarios.
- The previously intermittent tracking-radius action passed 3/3 repeated live API runs.
- `git diff --check` passed.
