### PR TITLE
Improve assistant guidance and multi-step form actions

### DIFF
--- a/behav3d/napari/_assistant.py
+++ b/behav3d/napari/_assistant.py
@@ -46,6 +46,11 @@ _METADATA_FIELD_DEFAULTS = {
     "time_unit": "s",
 }
 
+_CHAT_ROLE_COLORS = {
+    "assistant": "#30363b",
+    "user": "#173847",
+}
+
 
 def _coerce_bool(value) -> bool:
     if isinstance(value, str):
@@ -235,6 +240,28 @@ def researcher_facing_text(text: str) -> str:
         result = result.replace(technical, label)
         result = result.replace(f"`{label}`", label)
     return result.replace("`", "")
+
+
+def streaming_transcript_block(request_active: bool, streaming_text: str | None) -> str | None:
+    """Return the visible assistant block while a request is in progress."""
+    if streaming_text is None:
+        return None
+    body = streaming_text or (
+        "*Preparing a response...*" if request_active else ""
+    )
+    if not body:
+        return None
+    return f"**BEHAV3D Assistant**\n\n{body}"
+
+
+def transcript_block_role(text: str, current_role: str | None = None) -> str | None:
+    """Track the speaker while walking blocks produced by ``setMarkdown``."""
+    label = str(text or "").strip()
+    if label == "You":
+        return "user"
+    if label == "BEHAV3D Assistant":
+        return "assistant"
+    return current_role
 
 
 class _ChatInput(QPlainTextEdit):
@@ -492,11 +519,13 @@ class AssistantDock(QWidget):
         # Any direct/full render supersedes a pending throttled one.
         self._render_timer.stop()
         blocks = list(self._md_log)
-        if self._streaming_text:
-            blocks.append(f"**BEHAV3D Assistant**\n\n{self._streaming_text}")
+        streaming = streaming_transcript_block(
+            self._request_active, self._streaming_text
+        )
+        if streaming:
+            blocks.append(streaming)
         try:
-            # A thin rule between turns gives clear visual separation.
-            self.transcript.setMarkdown("\n\n---\n\n".join(blocks))
+            self.transcript.setMarkdown("\n\n".join(blocks))
             if style:
                 self._style_blocks()
         except Exception:
@@ -520,22 +549,35 @@ class AssistantDock(QWidget):
         """setMarkdown renders paragraphs/lists very tightly. Walk the document
         and add line spacing + paragraph spacing so responses are readable."""
         try:
-            from qtpy.QtGui import QTextCursor, QTextBlockFormat
+            from qtpy.QtGui import (
+                QBrush, QColor, QTextCursor, QTextBlockFormat,
+            )
         except Exception:
             return
         doc = self.transcript.document()
         block = doc.begin()
+        role = None
         while block.isValid():
             cur = QTextCursor(block)
             bf = cur.blockFormat()
+            previous_role = role
+            role = transcript_block_role(block.text(), role)
+            is_role_label = role != previous_role
             bf.setLineHeight(140, QTextBlockFormat.ProportionalHeight)  # 1.4× line spacing
-            bf.setTopMargin(2.0)
-            bf.setBottomMargin(9.0)                                     # gap between paragraphs
+            bf.setTopMargin(8.0 if is_role_label else 2.0)
+            bf.setBottomMargin(5.0)
+            if role in _CHAT_ROLE_COLORS:
+                bf.setBackground(QBrush(QColor(_CHAT_ROLE_COLORS[role])))
+                bf.setLeftMargin(10.0)
+                bf.setRightMargin(10.0)
             cur.setBlockFormat(bf)
             block = block.next()
 
     def _append_md(self, markdown: str):
-        self._md_log.append(markdown)
+        content = str(markdown or "").lstrip()
+        if not content.startswith(("**You**", "**BEHAV3D Assistant**")):
+            content = f"**BEHAV3D Assistant**\n\n{content}"
+        self._md_log.append(content)
         self._render()
 
     def _append_user(self, text: str):

--- a/behav3d/napari/_assistant_actions.py
+++ b/behav3d/napari/_assistant_actions.py
@@ -568,6 +568,18 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def normalize_metadata_line_value(value: Any) -> Any:
+    """Use the CSV-safe sentinel for a configured population that is absent."""
+    if value is None:
+        return "not_added"
+    normalized = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {
+        "none", "null", "n/a", "na", "absent", "not_added", "(not_added)",
+    }:
+        return "not_added"
+    return value
+
+
 def _coerce_control_value(control: dict, value: Any) -> tuple[bool, Any, str]:
     current = control.get("value")
     try:
@@ -629,8 +641,11 @@ def build_actions(
         if name == "set_ui_value":
             control_id = str(args.get("control_id") or "")
             control = next((c for c in (controls or []) if c.get("id") == control_id), None)
+            requested_value = args.get("value")
+            if control_id.startswith("metadata.samples.") and control_id.endswith(".line"):
+                requested_value = normalize_metadata_line_value(requested_value)
             act = ProposedAction("set_ui_value", control_id=control_id,
-                                 value=args.get("value"))
+                                 value=requested_value)
             if control is None:
                 act.ok = False
                 act.message = "That field is not available in the current interface."
@@ -641,7 +656,7 @@ def build_actions(
                 act.ok = False
                 act.message = "That field belongs to a different method than the one selected."
             else:
-                ok, coerced, message = _coerce_control_value(control, args.get("value"))
+                ok, coerced, message = _coerce_control_value(control, requested_value)
                 act.ok, act.message = ok, message
                 act.data.update(value=coerced, label=control.get("label"),
                                 old_value=control.get("value"))
@@ -693,6 +708,8 @@ def build_actions(
         elif name == "fill_metadata_builder":
             field = args.get("field")
             value = args.get("value")
+            if field == "cell_line":
+                value = normalize_metadata_line_value(value)
             index = _safe_int(args.get("index", 0), 0)
             act = ProposedAction(
                 "fill_metadata_builder",
@@ -714,6 +731,12 @@ def build_actions(
             actions.append(act)
         elif name == "bulk_fill_metadata":
             samples = args.get("samples", []) or []
+            for sample in samples:
+                if not isinstance(sample, dict):
+                    continue
+                for values in (sample.get("cell_types") or {}).values():
+                    if isinstance(values, dict) and "line" in values:
+                        values["line"] = normalize_metadata_line_value(values["line"])
             act = ProposedAction(
                 "bulk_fill_metadata",
                 n_samples=args.get("n_samples"),
@@ -1677,9 +1700,10 @@ TOOL_SCHEMA = [
                         "sample_name, exp_nr, well, raw_image_path, dimension_order, "
                         "pixel_distance_xy, pixel_distance_z, time_interval, time_unit, "
                         "dead_channel_number, dead_mask_path, and an optional "
-                        "'cell_types' object mapping each visible cell-type name to "
-                        "{line, condition, segments_image_path, tracks_image_path, "
-                        "tracks_csv_path}."
+                "'cell_types' object mapping each visible cell-type name to "
+                "{line, condition, segments_image_path, tracks_image_path, "
+                "tracks_csv_path}. For a configured population confirmed absent "
+                "from a sample, use the literal line value 'not_added'."
                     ),
                     "items": {"type": "object"},
                 },

--- a/behav3d/napari/_assistant_actions.py
+++ b/behav3d/napari/_assistant_actions.py
@@ -598,6 +598,14 @@ def _coerce_control_value(control: dict, value: Any) -> tuple[bool, Any, str]:
                 return False, coerced, f"Choose a value shown in {control.get('label', 'this control')}."
             resolved.append(match)
         coerced = resolved if isinstance(coerced, list) else resolved[0]
+    required_choices = control.get("required_choices") or []
+    if isinstance(coerced, list) and not set(required_choices).issubset(set(coerced)):
+        required_labels = ", ".join(str(item) for item in required_choices)
+        return (
+            False,
+            coerced,
+            f"{control.get('label', 'This selection')} must keep: {required_labels}.",
+        )
     minimum, maximum = control.get("minimum"), control.get("maximum")
     if minimum is not None and isinstance(coerced, (int, float)) and coerced < minimum:
         return False, coerced, f"{control.get('label')} must be at least {minimum}."

--- a/behav3d/napari/_assistant_context.py
+++ b/behav3d/napari/_assistant_context.py
@@ -440,7 +440,7 @@ def validate_metadata_records(records: list[dict]) -> list[dict]:
 
         # Draft builder records keep line and condition as separate nested
         # fields. A line is mandatory for every configured population; condition
-        # is optional. Use the literal value "None" for a confirmed absent
+        # is optional. Use the literal value "not_added" for a confirmed absent
         # population so absence is explicit rather than indistinguishable from an
         # unfinished row.
         for cell_type, fields in (record.get("cell_types") or {}).items():
@@ -534,7 +534,7 @@ _METADATA_FIELD_REQUIREMENTS = {
         "Dead-mask path",
     ],
     "absence_value": (
-        'Use "None" as the line only after the researcher confirms that a '
+        'Use "not_added" as the line only after the researcher confirms that a '
         "configured population is absent from that sample."
     ),
 }

--- a/behav3d/napari/_assistant_context.py
+++ b/behav3d/napari/_assistant_context.py
@@ -1114,11 +1114,49 @@ def _feature_extraction_state(main_widget) -> dict:
             lambda: [str(item.text()) for item in target_list.selectedItems()],
             [],
         ) or []
+    use_absolute = bool(_widget_value(
+        getattr(active, "check_abs_threshold", None)
+    ))
+    absolute_threshold = _widget_value(
+        getattr(active, "spin_abs_threshold", None)
+    )
+    observation_window = _widget_value(
+        getattr(active, "spin_obs_window", None)
+    )
+    minimum_contact = _widget_value(
+        getattr(active, "spin_min_contact", None)
+    )
+    effector = _widget_value(getattr(active, "immune_combo", None))
+    issues = []
+    if not effector or str(effector).startswith("(no immune"):
+        issues.append("Select an immune effector cell type.")
+    if not targets:
+        issues.append("Select at least one target cell type.")
+    if use_absolute:
+        try:
+            if float(absolute_threshold) <= 0:
+                issues.append(
+                    "Absolute signal-increase threshold must be greater than 0."
+                )
+        except (TypeError, ValueError):
+            issues.append("Set a valid absolute signal-increase threshold.")
     return {
         "active_killing_open": expanded,
         "active_killing": {
-            "effector_cell_type": _widget_value(getattr(active, "immune_combo", None)),
+            "effector_cell_type": effector,
             "target_cell_types": targets,
+            "observation_window": observation_window,
+            "death_signal": _widget_value(
+                getattr(active, "death_signal_combo", None)
+            ),
+            "uses_absolute_threshold": use_absolute,
+            "absolute_threshold": absolute_threshold,
+            "threshold_multiplier": _widget_value(
+                getattr(active, "spin_threshold_mult", None)
+            ),
+            "minimum_contact_duration": minimum_contact,
+            "setup_ready": not issues,
+            "setup_issues": issues,
         },
     }
 

--- a/behav3d/napari/_assistant_controls.py
+++ b/behav3d/napari/_assistant_controls.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 
-CONTROL_CONTRACT_VERSION = "3.1"
+CONTROL_CONTRACT_VERSION = "3.2"
 
 
 def _safe(fn: Callable, default=None):
@@ -153,6 +153,13 @@ def _checkset_binding(control_id, label, checks, **kwargs):
     item = _binding(control_id, label, first, getter=get, setter=set_, **kwargs)
     item["choices"] = list(checks)
     item["enabled"] = any(_is_enabled(check) for check in checks.values())
+    item["editable_choices"] = [
+        name for name, check in checks.items() if _is_enabled(check)
+    ]
+    item["required_choices"] = [
+        name for name, check in checks.items()
+        if not _is_enabled(check) and _safe(check.isChecked, False)
+    ]
     return item
 
 
@@ -870,9 +877,14 @@ def _feature_bindings(main_widget) -> list[dict]:
                     f"Active Killing: {label}", widget,
                     step="feature_extraction", unit=unit,
                     method="Active Killing", cell_type=immune,
-                    visible=expanded and relevant,
+                    visible=expanded,
                     **binding_kwargs,
                 )
+                if suffix in {"threshold_multiplier", "absolute_threshold"}:
+                    # Both alternatives must remain addressable in one assistant
+                    # proposal when the mode checkbox also changes.
+                    item["enabled"] = expanded
+                    item["active"] = relevant
                 if suffix == "death_signal":
                     item["choices"] = list(_ACTIVE_KILLING_SIGNAL_LABELS.values())
                 out.append(item)

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -46,7 +46,7 @@ _TOOL_NAMES = (
     "open_analysis_view",
 )
 _TOOL_NAME_PATTERN = "|".join(re.escape(name) for name in _TOOL_NAMES)
-CONTROL_CONTRACT_VERSION = "3.1"
+CONTROL_CONTRACT_VERSION = "3.2"
 _RESEARCHER_LABELS = {
     "pixel_distance_xy": "XY pixel size",
     "pixel_distance_z": "Z pixel size",
@@ -69,6 +69,20 @@ _RESEARCHER_LABELS = {
     "open_analysis_view": "open analysis view",
     "line_condition": "line and condition",
 }
+_MOVEMENT_FEATURE_NAMES = (
+    "displacement",
+    "cumulative_displacement",
+    "displacement_from_origin",
+    "mean_square_displacement",
+    "speed",
+    "mean_speed",
+    "summed_displacement",
+    "net_displacement",
+    "straightness",
+    "directional_persistence",
+    "median_turning_angle",
+    "fraction_reversed_movement",
+)
 
 
 def researcher_facing_text(text: str) -> str:
@@ -89,6 +103,26 @@ def split_researcher_stream_buffer(buffer: str, final: bool = False) -> tuple[st
         return "", buffer
     cutoff = whitespace[-1].end()
     return researcher_facing_text(buffer[:cutoff]), buffer[cutoff:]
+
+
+def _feature_label(value: str) -> str:
+    return str(value or "").replace("_", " ").strip().capitalize()
+
+
+def _previous_assistant_message(messages: list[dict]) -> str:
+    return next((
+        str(message.get("content") or "")
+        for message in reversed(messages[:-1])
+        if message.get("role") == "assistant"
+    ), "")
+
+
+def _visible_control_map(context: dict) -> dict[str, dict]:
+    return {
+        str(control.get("id") or ""): control
+        for control in ((context.get("ui_state", {}) or {}).get("controls", []) or [])
+        if control.get("id") and control.get("visible", True)
+    }
 
 
 def tools_for_context(tools: list[dict], context: dict) -> list[dict]:
@@ -1558,6 +1592,398 @@ def segmentation_minimum_size_action(
     return {"text": text, "calls": calls}
 
 
+def feature_group_requirement_guidance(
+    context: dict, messages: list[dict],
+) -> str | None:
+    """Explain mandatory feature groups before the model suggests removing one."""
+    if context.get("current_step") != "feature_extraction":
+        return None
+    latest = _latest_user_message(messages).lower()
+    if not (
+        re.search(r"\badjust\s+(?:the\s+)?(?:t[\s-]?cells?|tcell)", latest)
+        or re.search(r"\b(?:drop|remove|disable)\s+intensity\b", latest)
+        or (
+            "feature group" in latest
+            and any(word in latest for word in ("adjust", "review", "which", "keep"))
+        )
+    ):
+        return None
+
+    cell_type = str(context.get("active_cell_type") or "")
+    controls = _visible_control_map(context)
+    control = next((
+        item for control_id, item in controls.items()
+        if control_id == f"features.{cell_type}.feature_groups"
+    ), None)
+    if control is None:
+        return None
+    required = list(control.get("required_choices") or [])
+    if not required:
+        return None
+    choices = list(control.get("choices") or [])
+    optional = [choice for choice in choices if choice not in required]
+    required_text = ", ".join(_feature_label(item) for item in required)
+    optional_text = ", ".join(_feature_label(item) for item in optional) or "none"
+    dead_context = (
+        " Because a dead channel is configured, Death is also required. "
+        "Intensity is kept because it calculates channel intensities, including "
+        "mean dead-dye intensity for this population."
+        if "death" in required else
+        " Intensity remains required because it provides the channel-intensity "
+        "measurements used downstream."
+    )
+    return (
+        f"For **{cell_type or 'the selected cell type'}**, the live panel marks "
+        f"**{required_text}** as required, so I will not suggest removing them."
+        f"{dead_context} The optional groups are **{optional_text}**. Tell me which "
+        "optional groups matter to your biological question and I can adjust those."
+    )
+
+
+def _hmm_feature_controls(context: dict) -> dict[str, dict]:
+    if context.get("current_step") != "analysis":
+        return {}
+    analysis = context.get("analysis", {}) or {}
+    if analysis.get("view") != "behavioral_state":
+        return {}
+    cell_type = str(
+        analysis.get("selected_cell_type")
+        or context.get("active_cell_type")
+        or ""
+    )
+    prefix = f"analysis.state_classification.{cell_type or 'selected'}."
+    controls = _visible_control_map(context)
+    return {
+        suffix: controls[control_id]
+        for suffix in (
+            "timepoint_features", "window_features", "binary_feature_groups",
+        )
+        if (control_id := prefix + suffix) in controls
+    }
+
+
+def _movement_options(context: dict) -> dict[str, list[str]]:
+    controls = _hmm_feature_controls(context)
+    timepoint = controls.get("timepoint_features", {})
+    window = controls.get("window_features", {})
+    movement = set(_MOVEMENT_FEATURE_NAMES)
+    return {
+        "timepoint": [
+            str(choice) for choice in (timepoint.get("choices") or [])
+            if str(choice) in movement
+        ],
+        "window": [
+            str(choice) for choice in (window.get("choices") or [])
+            if str(choice) in movement
+        ],
+        "selected_timepoint": [
+            str(value) for value in (timepoint.get("value") or [])
+            if str(value) in movement
+        ],
+        "selected_window": [
+            str(value) for value in (window.get("value") or [])
+            if str(value) in movement
+        ],
+        "binary_available": [
+            str(choice)
+            for choice in (
+                controls.get("binary_feature_groups", {}).get("choices") or []
+            )
+        ],
+        "binary_selected": [
+            str(value)
+            for value in (
+                controls.get("binary_feature_groups", {}).get("value") or []
+            )
+        ],
+    }
+
+
+def hmm_movement_setup_action(
+    context: dict, messages: list[dict],
+) -> dict | None:
+    """Apply an explicit movement-feature choice across both HMM feature lists."""
+    controls = _hmm_feature_controls(context)
+    if not controls:
+        return None
+    latest = _latest_user_message(messages)
+    previous = _previous_assistant_message(messages)
+    if "available movement" not in previous.lower():
+        return None
+
+    options = _movement_options(context)
+    normalized = " ".join(latest.lower().replace("_", " ").split())
+    choose_all = bool(re.search(
+        r"\b(?:all|every)\b.*\bmovement\b|\buse all\b", normalized
+    ))
+    selected_timepoint = []
+    selected_window = []
+    if choose_all:
+        selected_timepoint = options["timepoint"]
+        selected_window = options["window"]
+    else:
+        for value in options["timepoint"]:
+            label = " ".join(value.lower().replace("_", " ").split())
+            if re.search(rf"\b{re.escape(label)}\b", normalized):
+                selected_timepoint.append(value)
+        for value in options["window"]:
+            label = " ".join(value.lower().replace("_", " ").split())
+            if re.search(rf"\b{re.escape(label)}\b", normalized):
+                selected_window.append(value)
+        if not selected_timepoint and not selected_window:
+            return None
+
+    calls = []
+    for suffix, values in (
+        ("timepoint_features", selected_timepoint),
+        ("window_features", selected_window),
+    ):
+        control = controls.get(suffix)
+        if control is not None and list(control.get("value") or []) != values:
+            calls.append({
+                "name": "set_ui_value",
+                "arguments": {"control_id": control["id"], "value": values},
+            })
+    timepoint_text = ", ".join(
+        _feature_label(value) for value in selected_timepoint
+    ) or "none"
+    window_text = ", ".join(
+        _feature_label(value) for value in selected_window
+    ) or "none"
+    binary_text = ", ".join(
+        _feature_label(value) for value in options["binary_selected"]
+    ) or "none"
+    return {
+        "text": (
+            "I am proposing the complete movement-only selection: timepoint "
+            f"features **{timepoint_text}** and window features **{window_text}**. "
+            f"The currently selected binary comparison groups are **{binary_text}**; "
+            "they stratify results after the HMM and do not train the states. "
+            + (
+                "Apply the action cards before running the analysis."
+                if calls else
+                "Those movement selections are already present, so no change is needed."
+            )
+        ),
+        "calls": calls,
+    }
+
+
+def hmm_movement_feature_guidance(
+    context: dict, messages: list[dict],
+) -> str | None:
+    """List every movement input available in the loaded HMM feature file."""
+    controls = _hmm_feature_controls(context)
+    if not controls:
+        return None
+    latest = _latest_user_message(messages).lower()
+    asks_movement = (
+        "movement feature" in latest
+        or "movement-only" in latest
+        or "only movement" in latest
+    )
+    asks_behavior_setup = (
+        "behavior" in latest
+        and any(word in latest for word in ("interaction", "contact", "tumor"))
+        and any(word in latest for word in ("fill", "set", "configure", "select"))
+    )
+    asks_selection_review = (
+        "all the features" in latest
+        or ("is it ready" in latest and "feature" in latest)
+    )
+    if not (asks_movement or asks_behavior_setup or asks_selection_review):
+        return None
+
+    options = _movement_options(context)
+    timepoint = ", ".join(
+        _feature_label(value) for value in options["timepoint"]
+    ) or "none found in the loaded feature file"
+    window = ", ".join(
+        _feature_label(value) for value in options["window"]
+    ) or "none available"
+    current_tp = ", ".join(
+        _feature_label(value) for value in options["selected_timepoint"]
+    ) or "none"
+    current_window = ", ".join(
+        _feature_label(value) for value in options["selected_window"]
+    ) or "none"
+    binary = ", ".join(
+        _feature_label(value) for value in options["binary_available"]
+    ) or "none detected"
+    return (
+        "The loaded T-cell feature file offers these **movement inputs**:\n\n"
+        f"- Per-timepoint features: **{timepoint}**\n"
+        f"- Rolling/window features: **{window}**\n\n"
+        f"Currently selected: per-timepoint **{current_tp}**; window "
+        f"**{current_window}**. Available binary comparison groups are "
+        f"**{binary}**. Binary contact groups are applied after the HMM, so they "
+        "compare state frequencies without defining the states. Choose the feature "
+        "names you want, or say **use all available movement features**, and I will "
+        "propose both feature lists together."
+    )
+
+
+def _number_from_proposal(text: str, patterns: tuple[str, ...]) -> float | None:
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            try:
+                return float(match.group(1))
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def active_killing_confirmation_action(
+    context: dict, messages: list[dict],
+) -> dict | None:
+    """Turn acceptance of a multi-field Active Killing proposal into one batch."""
+    if context.get("current_step") != "feature_extraction":
+        return None
+    latest = " ".join(_latest_user_message(messages).lower().split())
+    if not any(phrase in latest for phrase in (
+        "settings seem ok", "settings seem okay", "looks good", "apply them",
+        "apply these", "use those settings", "use these settings",
+        "yes set it up", "yes, set it up",
+    )):
+        return None
+    previous = _previous_assistant_message(messages)
+    if "active killing" not in previous.lower():
+        return None
+
+    controls = _visible_control_map(context)
+    expected: dict[str, object] = {}
+    by_suffix = {
+        suffix: controls.get(f"features.active_killing.{suffix}")
+        for suffix in (
+            "target_types", "observation_window", "death_signal",
+            "use_absolute_threshold", "absolute_threshold",
+            "minimum_contact_duration",
+        )
+    }
+    previous_lower = previous.lower()
+    target_control = by_suffix["target_types"]
+    if target_control is not None:
+        selected_targets = [
+            str(choice) for choice in (target_control.get("choices") or [])
+            if re.search(
+                rf"\b{re.escape(str(choice).lower())}\b", previous_lower
+            )
+        ]
+        if selected_targets:
+            expected["target_types"] = selected_targets
+
+    for label in (
+        "Dead-mask pixel count", "Dead-mask percentage",
+        "Mean dead-dye intensity",
+    ):
+        if label.lower() in previous_lower:
+            expected["death_signal"] = label
+            break
+
+    absolute_mode = "absolute threshold" in previous_lower
+    if absolute_mode:
+        expected["use_absolute_threshold"] = True
+        absolute_value = _number_from_proposal(previous, (
+            r"absolute (?:signal-increase )?threshold[^\d]{0,50}"
+            r"(\d+(?:\.\d+)?)\s*(?:dead[- ]mask |dead )?(?:pixels|voxels)",
+            r"minimum rise[^\d]{0,30}(\d+(?:\.\d+)?)\s*"
+            r"(?:dead[- ]mask |dead )?(?:pixels|voxels)",
+            r"(\d+(?:\.\d+)?)\s*(?:dead[- ]mask |dead )?(?:pixels|voxels)"
+            r"[^\n.]{0,35}(?:minimum|threshold|rise)",
+        ))
+        if absolute_value is None or absolute_value <= 0:
+            return {
+                "text": (
+                    "I have not applied a partial Active Killing setup. The agreed "
+                    "absolute-threshold mode still needs a positive minimum "
+                    "dead-mask pixel increase. Tell me that value, then I can propose "
+                    "the threshold, signal, timing, contact duration, and targets "
+                    "together."
+                ),
+                "calls": [],
+            }
+        expected["absolute_threshold"] = absolute_value
+
+    observation = _number_from_proposal(previous, (
+        r"observation window[^\d]{0,45}(\d+(?:\.\d+)?)\s*"
+        r"(?:timepoints?|frames?|tp)\b",
+        r"currently[^\n.]{0,25}(\d+(?:\.\d+)?)\s*"
+        r"(?:timepoints?|frames?|tp)\b",
+    ))
+    if observation is not None:
+        expected["observation_window"] = int(round(observation))
+    minimum_contact = _number_from_proposal(previous, (
+        r"(?:minimum|min\.?) contact duration[^\d]{0,45}"
+        r"(\d+(?:\.\d+)?)\s*(?:timepoints?|frames?|tp)\b",
+    ))
+    if minimum_contact is not None:
+        expected["minimum_contact_duration"] = int(round(minimum_contact))
+
+    calls = []
+    for suffix, value in expected.items():
+        control = by_suffix.get(suffix)
+        if control is not None:
+            calls.append({
+                "name": "set_ui_value",
+                "arguments": {"control_id": control["id"], "value": value},
+            })
+    if not calls:
+        return None
+    targets = expected.get("target_types") or (
+        target_control.get("value") if target_control else []
+    )
+    target_text = ", ".join(str(value) for value in targets) or "the selected targets"
+    return {
+        "text": (
+            "I am proposing the complete agreed Active Killing setup in one batch, "
+            f"for effector cells against **{target_text}**. BEHAV3D will run each "
+            "selected target independently and also create a combined analysis when "
+            "more than one target is selected. The setup is not ready until every "
+            "action card below has been applied; after that the live readiness state "
+            "will confirm it."
+        ),
+        "calls": calls,
+    }
+
+
+def active_killing_readiness_summary(
+    context: dict, messages: list[dict],
+) -> str | None:
+    if context.get("current_step") != "feature_extraction":
+        return None
+    latest = _latest_user_message(messages).lower()
+    if "active killing" not in " ".join(
+        str(message.get("content") or "").lower() for message in messages
+    ):
+        return None
+    if not any(phrase in latest for phrase in (
+        "is it set", "is it ready", "ready now", "setup complete",
+    )):
+        return None
+    state = (
+        (context.get("feature_extraction", {}) or {}).get("active_killing", {})
+        or {}
+    )
+    issues = list(state.get("setup_issues") or [])
+    if issues:
+        return (
+            "Active Killing is **not ready yet**. "
+            + " ".join(issues)
+            + " I will not describe the setup as complete until the live controls "
+            "contain every required value."
+        )
+    targets = ", ".join(state.get("target_cell_types") or []) or "none"
+    return (
+        "Active Killing is **ready** in the live controls: effector "
+        f"**{state.get('effector_cell_type')}**, targets **{targets}**, observation "
+        f"window **{state.get('observation_window')} timepoints**, and minimum "
+        f"contact **{state.get('minimum_contact_duration')} timepoints**. "
+        "When multiple targets are selected, BEHAV3D produces independent target "
+        "analyses and a combined analysis."
+    )
+
+
 def active_killing_action(context: dict, messages: list[dict]) -> dict | None:
     """Build the standard Active Killing proposal from target and cadence."""
     if context.get("current_step") != "feature_extraction":
@@ -1570,11 +1996,14 @@ def active_killing_action(context: dict, messages: list[dict]) -> dict | None:
     text = latest.lower()
     if "configure active killing" not in text:
         return None
-    target_match = re.search(r"\bagainst\s+([a-z0-9_ -]+?)\s+only\b", text)
+    target_match = re.search(
+        r"\bagainst\s+([a-z0-9_ ,&/-]+?)(?:\s+only)?(?:[.;]|\s+within\b)",
+        text,
+    )
     window_match = re.search(r"\bwithin\s+(\d+(?:\.\d+)?)\s+minutes?\b", text)
     if target_match is None or window_match is None:
         return None
-    target = target_match.group(1).strip()
+    target_text = target_match.group(1).strip()
     duration_minutes = float(window_match.group(1))
 
     records = (context.get("metadata", {}) or {}).get("records", []) or []
@@ -1603,11 +2032,39 @@ def active_killing_action(context: dict, messages: list[dict]) -> dict | None:
         for control in controls
         if control.get("visible", True) and control.get("enabled", True)
     }
+    target_control = by_id.get("features.active_killing.target_types", {})
+    target_choices = [str(value) for value in (target_control.get("choices") or [])]
+    targets = [
+        choice for choice in target_choices
+        if re.search(rf"\b{re.escape(choice.lower())}\b", target_text)
+    ]
+    if not targets:
+        targets = [
+            value.strip()
+            for value in re.split(r"\s*(?:,|&|\band\b)\s*", target_text)
+            if value.strip()
+        ]
+    absolute_threshold = _number_from_proposal(latest, (
+        r"absolute (?:signal-increase )?threshold[^\d]{0,30}"
+        r"(\d+(?:\.\d+)?)\s*(?:dead[- ]mask |dead )?(?:pixels|voxels)",
+    ))
+    if absolute_threshold is None or absolute_threshold <= 0:
+        return {
+            "text": (
+                f"The timing converts to **{window} timepoints** at {interval:g} "
+                f"{record.get('time_unit') or ''} per frame. Before I propose the "
+                "complete Active Killing setup, I still need one value: the positive "
+                "minimum dead-mask pixel increase for the absolute threshold. I will "
+                "not enable absolute-threshold mode while that value remains 0."
+            ),
+            "calls": [],
+        }
     expected = {
-        "features.active_killing.target_types": [target],
+        "features.active_killing.target_types": targets,
         "features.active_killing.observation_window": window,
         "features.active_killing.death_signal": "Dead-mask pixel count",
         "features.active_killing.use_absolute_threshold": True,
+        "features.active_killing.absolute_threshold": absolute_threshold,
     }
     if not set(expected).issubset(by_id):
         return None
@@ -1615,9 +2072,11 @@ def active_killing_action(context: dict, messages: list[dict]) -> dict | None:
         "text": (
             f"Based on {duration_minutes:g} minutes at {interval:g} "
             f"{record.get('time_unit') or ''} per frame, I’m proposing an Observation "
-            f"window of {window} timepoints, target {target} only, Dead-mask pixel "
-            "count, and an absolute threshold. These changes still require your "
-            "confirmation in the action cards."
+            f"window of {window} timepoints, target{'s' if len(targets) != 1 else ''} "
+            f"{', '.join(targets)}, Dead-mask pixel count, and an absolute threshold "
+            f"of {absolute_threshold:g}. BEHAV3D runs every selected target "
+            "independently and adds a combined analysis when multiple targets are "
+            "selected. These changes still require your confirmation in the action cards."
         ),
         "calls": [
             {
@@ -1754,8 +2213,8 @@ def safety_profile_summary(context: dict, messages: list[dict]) -> str | None:
         "**Active Killing definition:** The experiment reference defines an event "
         "as a contact-associated relative rise in dead-mask percentage to at least "
         f"1.5× baseline within {window_text}, after at least one frame of contact. "
-        "If you run the module, analyse 27T and MDO separately because it accepts "
-        f"one target type per run. {result_note}"
+        "If you run the module, select both 27T and MDO: BEHAV3D creates an "
+        f"independent analysis for each target plus a combined analysis. {result_note}"
     )
 
 
@@ -2059,16 +2518,28 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "lowering it to reduce RAM. When multiple organoid types exist, "
         "recommend tracking all organoid types together with Propagation.\n"
         "- In Feature Extraction, recommend Morphology only when shape is biologically relevant and Movement "
-        "for motility. Contact distance 0 means strict touching; larger values mean proximity, and any change "
+        "for motility. Read required_choices on every feature-group control before recommending a removal. "
+        "Intensity and Contact are required for every cell type, Movement is required for immune/other cells, "
+        "and Death is required when a dead channel is configured. Intensity includes mean dead-dye and other "
+        "channel-intensity measurements, so never suggest dropping it from a T-cell population with a dead "
+        "channel. Contact distance 0 means strict touching; larger values mean proximity, and any change "
         "requires feature extraction to be run again. A positive contact distance equal to the XY pixel "
         "size permits a one-XY-pixel gap; it is not strict touching and is not a voxel diagonal.\n"
-        "- In Active Killing, configure one target type per run. Derive Observation window and Minimum contact "
+        "- In Active Killing, the target selector may contain multiple target types. One run automatically "
+        "produces an independent analysis for each selected target and an additional combined analysis when "
+        "more than one is selected; never tell the user to configure separate UI runs. Derive Observation "
+        "window and Minimum contact "
         "duration from the biological timescale and metadata time interval. Prefer dead-mask pixel count with "
         "an absolute threshold by default; calibrate that threshold from cell size and XY pixel size. Do not "
         "reuse a 20-30 pixel example blindly. Use relative multipliers only in the limited baseline contexts "
         "described in the guidance. In study-design explanations, call the immune cell the effector and the "
         "organoid or cell being contacted the target; never describe an immune effector such as TEG as a "
         "target. With one immune type and two organoid types, say one effector type and two target types. "
+        "An accepted multi-parameter setup must propose every agreed value in the same response: targets, "
+        "death signal, threshold mode and value, observation window, and minimum contact duration. Never "
+        "apply only the mode checkbox while leaving an agreed absolute threshold at 0. The dependent "
+        "threshold controls remain editable when inactive; read their active flag rather than omitting them. "
+        "Do not say the setup is ready until the live Active Killing state reports setup_ready true. "
         "When an experiment reference defines Active Killing settings, say the reference 'defines' or "
         "'describes' them, never 'you have configured' or 'already configured' unless live controls/results "
         "prove that. Preserve a stated one-frame minimum exactly; do not replace it with a generic 1-3-frame "
@@ -2084,7 +2555,12 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "- Behavioral State and State Trajectory are different analysis views. For HMM state classification, "
         "use fixed state count, keep Start offset at 1, use Window size 5 by default or 1 for single-frame "
         "events, and usually match Smooth window to Window size. Log-scale only inspected skewed features, do "
-        "not routinely percentile-clip, and explain that binary groups are applied after the HMM.\n"
+        "not routinely percentile-clip, and explain that binary groups are applied after the HMM. When the "
+        "researcher asks for movement-only states or asks whether movement features are complete, enumerate "
+        "all movement choices from both the live Timepoint features and Additional window features controls. "
+        "Distinguish instantaneous/accumulated movement, directionality, and rolling trajectory summaries. "
+        "Do not present the currently selected speed and net displacement as the complete option set. Ask the "
+        "researcher to choose, then propose both feature lists together rather than partially setting one.\n"
         "- For State Trajectory, Trajectory size cannot exceed the Filtering trim. Average linkage is the "
         "default, Complete is a reasonable comparison, and Single performs poorly. Original BEHAV3D mode is "
         "deprecated. Be transparent that contact-based comparison plots and exemplar-track exports are known "
@@ -2391,6 +2867,8 @@ if modal is not None:
                 or segmentation_minimum_size_action(context, messages)
                 or tracking_radius_action(context, messages)
                 or btrack_step2_action(context, messages)
+                or hmm_movement_setup_action(context, messages)
+                or active_killing_confirmation_action(context, messages)
                 or active_killing_action(context, messages)
             )
             available_tool_names = {tool.get("name") for tool in tools}
@@ -2420,6 +2898,9 @@ if modal is not None:
                 or metadata_completion_summary(context, messages)
                 or analysis_choice_summary(context, messages)
                 or safety_profile_summary(context, messages)
+                or active_killing_readiness_summary(context, messages)
+                or feature_group_requirement_guidance(context, messages)
+                or hmm_movement_feature_guidance(context, messages)
                 or apoc_channel_selection_guidance(context, messages)
                 or apoc_feature_grid_guidance(context, messages)
                 or edt_direction_guidance(context, messages)

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -231,8 +231,73 @@ def metadata_identifier_confirmation_question(
         "propose **1** for every sample. Before I fill the line fields, please confirm: "
         "should each line you gave apply to all relevant samples, should M21/M23 be "
         "inferred only where those suffixes appear in a filename, and should a sample "
-        "without a macrophage suffix use **None** to mean macrophages are absent?"
+        "without a macrophage suffix be described as **not added** and use the line "
+        "value **not_added**?"
     )
+
+
+def metadata_absence_action(context: dict, messages: list[dict]) -> dict | None:
+    """Write the CSV-safe line sentinel for an explicitly absent population."""
+    if context.get("current_step") != "data_preparation":
+        return None
+    latest = _latest_user_message(messages)
+    normalized = " ".join(re.sub(r"[^a-z0-9]+", " ", latest.lower()).split())
+    if not (
+        any(phrase in normalized for phrase in (
+            "not added", "was not added", "were not added", "is absent",
+            "are absent", "no macrophage", "no t cell", "use none",
+        ))
+        and re.search(r"\b(?:set|fill|mark|line|metadata|use|make)\b", normalized)
+    ):
+        return None
+    candidates = [
+        control
+        for control in _visible_control_map(context).values()
+        if str(control.get("id") or "").startswith("metadata.samples.")
+        and str(control.get("id") or "").endswith(".line")
+        and control.get("enabled", True)
+    ]
+    sample_match = re.search(r"\bsample\s*(\d+)\b", normalized)
+    if sample_match:
+        sample_index = int(sample_match.group(1)) - 1
+        candidates = [
+            control for control in candidates
+            if f"metadata.samples.{sample_index}." in str(control.get("id") or "")
+        ]
+    population_matches = []
+    for control in candidates:
+        control_id = str(control.get("id") or "")
+        match = re.search(r"\.cell_types\.(.+)\.line$", control_id)
+        cell_type = match.group(1) if match else str(control.get("cell_type") or "")
+        alias = " ".join(re.sub(
+            r"[^a-z0-9]+", " ", cell_type.lower()
+        ).split())
+        if alias and alias in normalized:
+            population_matches.append(control)
+    if population_matches:
+        candidates = population_matches
+    if len(candidates) != 1:
+        return None
+    control = candidates[0]
+    label = str(control.get("label") or "the selected population line")
+    if str(control.get("value") or "").strip().lower() == "not_added":
+        return {
+            "text": (
+                f"**{label}** already records that the population was **not added** "
+                "using the line value **not_added**."
+            ),
+            "calls": [],
+        }
+    return {
+        "text": (
+            f"I will record **{label}** as **not added** using the CSV-safe line "
+            "value **not_added**."
+        ),
+        "calls": [{
+            "name": "set_ui_value",
+            "arguments": {"control_id": control["id"], "value": "not_added"},
+        }],
+    }
 
 
 def metadata_completion_summary(context: dict, messages: list[dict]) -> str | None:
@@ -277,7 +342,8 @@ def metadata_completion_summary(context: dict, messages: list[dict]) -> str | No
             "Not yet. These mandatory metadata values are still missing:\n"
             f"{shown}{extra}\n\nPopulation **condition** fields are optional; "
             "population **line** fields are mandatory. A population confirmed absent "
-            "from a sample should use **None** for its line rather than remain blank."
+            "from a sample should be described as **not added** and use "
+            "**not_added** for its line rather than remain blank."
             f"{well_note}"
         )
     save_available = bool((builder.get("actions") or {}).get("save_available"))
@@ -293,21 +359,153 @@ def metadata_completion_summary(context: dict, messages: list[dict]) -> str | No
     )
 
 
+def _metadata_analysis_profile(context: dict) -> dict:
+    """Extract a compact experiment profile for analysis recommendations."""
+    metadata = context.get("metadata", {}) or {}
+    records = metadata.get("records", []) or []
+    configured = metadata.get("cell_types", {}) or {}
+    populations = {
+        category: [str(value) for value in (configured.get(category) or [])]
+        for category in ("organoid", "immune", "other")
+    }
+    line_values = []
+    dead_signal = False
+
+    def add_line(value) -> None:
+        text = str(value or "").strip()
+        if (
+            text
+            and text.lower() not in {
+                "nan", "none", "null", "not_added", "(not_added)",
+            }
+            and text not in line_values
+        ):
+            line_values.append(text)
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        for key, value in record.items():
+            key_text = str(key)
+            for prefix, category in (
+                ("or_", "organoid"), ("im_", "immune"), ("ot_", "other"),
+            ):
+                if key_text.startswith(prefix) and "_line_condition" in key_text:
+                    name = key_text[len(prefix):].split("_line_condition", 1)[0]
+                    if name and name not in populations[category]:
+                        populations[category].append(name)
+            if key_text.endswith("_line_condition"):
+                add_line(value)
+            if key_text in {"dead_channel", "dead_channel_number", "dead_mask_path"}:
+                dead_signal = dead_signal or (
+                    value is not None
+                    and str(value).strip().lower() not in {"", "nan", "none", "null"}
+                )
+        for _cell_type, fields in (record.get("cell_types") or {}).items():
+            if isinstance(fields, dict):
+                add_line(fields.get("line"))
+
+    return {
+        "n_samples": metadata.get("n_samples") or len(records),
+        "populations": populations,
+        "line_values": line_values,
+        "dead_signal": dead_signal,
+    }
+
+
 def analysis_choice_summary(context: dict, messages: list[dict]) -> str | None:
-    """Make the Choose analysis quick action explanatory rather than navigational."""
+    """List every analysis route and connect it to the live experiment design."""
     latest = " ".join(_latest_user_message(messages).lower().split())
     intent = str((context.get("assistant_session") or {}).get("intent") or "")
-    if intent != "choose_analysis" and latest not in {
-        "choose analysis", "which analysis", "help me choose an analysis",
-    }:
+    targeted_single_cell = any(phrase in latest for phrase in (
+        "classify behavioral tracks", "classify behavioural tracks",
+        "state trajectory", "track classification",
+    ))
+    asks_general = (
+        bool(re.search(
+            r"\b(?:what|which|choose|pick)\b.{0,28}\banalys(?:is|es)\b",
+            latest,
+        ))
+        or "analysis would be nice" in latest
+        or "analysis is possible" in latest
+        or "help me choose an analysis" in latest
+    )
+    if (intent != "choose_analysis" and not asks_general) or targeted_single_cell:
         return None
+
+    profile = _metadata_analysis_profile(context)
+    populations = profile["populations"]
+    all_populations = (
+        populations["organoid"] + populations["immune"] + populations["other"]
+    )
+    snapshot = ""
+    if profile["n_samples"] or all_populations:
+        sample_text = (
+            f"**{profile['n_samples']} samples**"
+            if profile["n_samples"] else "the loaded samples"
+        )
+        population_text = (
+            ", ".join(all_populations) if all_populations else "no populations detected"
+        )
+        lines = ", ".join(profile["line_values"][:8])
+        snapshot = (
+            f"From the live metadata I see {sample_text} with **{population_text}**."
+            + (f" Recorded lines/conditions include **{lines}**." if lines else "")
+            + "\n\n"
+        )
+
+    questions = []
+    if populations["organoid"]:
+        questions.append(
+            "Do target or organoid lines differ in death timing? Start with "
+            "**Death Dynamics**."
+        )
+    if populations["organoid"] and populations["immune"]:
+        questions.extend([
+            "Do immune contacts differ by target condition, and are they associated "
+            "with death? Use **Interaction Analysis**.",
+            "Do immune cells engage or enter targets to different degrees? Use "
+            "**Invasiveness Analysis**, if invasiveness features were extracted.",
+        ])
+    if populations["immune"]:
+        questions.append(
+            "Do immune populations occupy different dynamic states or complete "
+            "different behavioral programs? Use **Behavioral State**, then "
+            "**State Trajectory**."
+        )
+    if populations["organoid"] and populations["immune"] and profile["dead_signal"]:
+        questions.append(
+            "Which individual immune cells show contact-associated target killing? "
+            "Use **Active Killing** after feature extraction."
+        )
+    if not questions:
+        questions.append(
+            "Choose the route from the biological question and confirm its listed "
+            "prerequisites before running it."
+        )
+    question_text = "\n".join(f"- {question}" for question in questions)
     return (
-        "Choose the analysis from the biological question:\n"
-        "- **Death Dynamics**: quantify target or organoid death over time and inspect "
-        "death-related interaction summaries.\n"
-        "- **Behavioral State**: assign a recurring state to each cell at each timepoint.\n"
-        "- **State Trajectory**: group whole-cell state sequences across time.\n\n"
-        "What do you want to learn from the experiment?"
+        f"{snapshot}"
+        "BEHAV3D offers these analysis routes:\n"
+        "1. **Death Dynamics** - target survival, death timing, and disappearance.\n"
+        "2. **Interaction Analysis** - target-centered contact patterns and their "
+        "relationship to death.\n"
+        "3. **Invasiveness Analysis** - immune-cell engagement with targets over time "
+        "and per movie.\n"
+        "4. **Active Killing** - contact-associated target death attributed to "
+        "individual immune cells; configured under Feature Extraction.\n"
+        "5. **Behavioral State** - an HMM state for each selected-cell timepoint.\n"
+        "6. **State Trajectory** - clusters whole state sequences into behavioral "
+        "programs.\n"
+        "7. **Backprojection** - overlays state, trajectory, or killing results on the "
+        "images for visual validation.\n\n"
+        "**Questions suggested by your metadata**\n"
+        f"{question_text}\n\n"
+        "For an immune-cell behavior question, the usual sequence is **Behavioral "
+        "State -> rename or merge states -> State Trajectory -> Backprojection**. "
+        "For a target-killing question, start with **Death Dynamics**, then add "
+        "**Interaction/Invasiveness** and **Active Killing** where their prerequisites "
+        "are available."
     )
 
 
@@ -1662,6 +1860,228 @@ def _hmm_feature_controls(context: dict) -> dict[str, dict]:
     }
 
 
+def _selected_hmm_cell_type(context: dict) -> str:
+    analysis = context.get("analysis", {}) or {}
+    return str(
+        analysis.get("selected_cell_type")
+        or context.get("active_cell_type")
+        or "the selected cell type"
+    )
+
+
+def _hmm_control_prefix(context: dict) -> str:
+    return f"analysis.state_classification.{_selected_hmm_cell_type(context)}."
+
+
+def hmm_setup_guidance(context: dict, messages: list[dict]) -> str | None:
+    """Guide Behavioral State from the controls for the currently selected cell type."""
+    controls = _hmm_feature_controls(context)
+    latest = _latest_user_message(messages).lower()
+    if not controls or not (
+        ("behavioral analysis" in latest or "behavioural analysis" in latest)
+        and any(word in latest for word in ("guide", "steps", "walk", "take me"))
+    ):
+        return None
+    cell_type = _selected_hmm_cell_type(context)
+    options = _movement_options(context)
+    timepoint = ", ".join(
+        _feature_label(value)
+        for value in controls.get("timepoint_features", {}).get("value", [])
+    ) or "none selected"
+    window = ", ".join(
+        _feature_label(value)
+        for value in controls.get("window_features", {}).get("value", [])
+    ) or "none selected"
+    binary = ", ".join(
+        _feature_label(value) for value in options["binary_selected"]
+    ) or "none selected"
+    live = _visible_control_map(context)
+    prefix = _hmm_control_prefix(context)
+    state_count = live.get(prefix + "n_states", {}).get("value")
+    state_text = (
+        f" The requested number of states is **{state_count}**."
+        if state_count is not None else ""
+    )
+    return (
+        f"You currently have **{cell_type}** selected, so this setup and every "
+        "recommendation below apply to that population.\n\n"
+        "1. Review the continuous HMM inputs. Current per-timepoint features: "
+        f"**{timepoint}**; current window features: **{window}**.\n"
+        "2. Keep binary groups separate from HMM training. Current binary groups: "
+        f"**{binary}**.{state_text}\n"
+        "3. Run State Classification and inspect the feature heatmap, per-state "
+        "distributions, and example state bars.\n"
+        "4. In Step 2, rename the primary states by biological meaning; reuse a name "
+        "to merge redundant states.\n"
+        "5. Review and rename the full behavioral clusters created by combining those "
+        "states with the binary groups.\n"
+        "6. Create reports and use Backprojection to verify the labels on the images.\n\n"
+        "Tell me whether your main question is movement, morphology, target contact, "
+        "or another behavior, and I can review the live feature choices for "
+        f"**{cell_type}**."
+    )
+
+
+def _binary_group_description(choice: str, selected_cell_type: str) -> str:
+    normalized = str(choice or "").strip()
+    lower = normalized.lower()
+    label = _feature_label(normalized)
+    selected = f"a cell from {selected_cell_type}"
+    if lower == "dead":
+        return f"{selected} is marked dead at that timepoint"
+    if "mean_dead_dye" in lower or "mean dead" in lower:
+        return f"{selected} is grouped by its dead-dye signal"
+    if lower == "interpolated":
+        return f"that {selected_cell_type} timepoint was gap-filled during tracking"
+    if lower == "border_touching_segment":
+        return f"the selected {selected_cell_type} segment touches the image border"
+    if "invasiveness" in lower:
+        target = normalized.split("_invasiveness", 1)[0].replace("_", " ")
+        return (
+            f"{selected} meets the invasiveness criterion for "
+            f"{target or 'a target'}"
+        )
+    if "contact_on_distance" in lower:
+        target = normalized.split("_contact_on_distance", 1)[0].replace("_", " ")
+        return (
+            f"{selected} is within the configured contact distance of "
+            f"{target or 'another population'}"
+        )
+    if lower.endswith("_contact"):
+        target = normalized[:-len("_contact")].replace("_", " ")
+        return (
+            f"{selected} is directly touching "
+            f"{target or 'another population'}"
+        )
+    return f"the live feature flag **{label}** is true for {selected}"
+
+
+def hmm_binary_group_action(
+    context: dict, messages: list[dict],
+) -> dict | None:
+    """Add explicitly requested binary groups for the selected HMM cell type."""
+    controls = _hmm_feature_controls(context)
+    control = controls.get("binary_feature_groups")
+    if control is None:
+        return None
+    latest = _latest_user_message(messages)
+    normalized = " ".join(re.sub(r"[^a-z0-9]+", " ", latest.lower()).split())
+    if not re.search(r"\b(?:add|include|select|set)\b", normalized):
+        return None
+    requested = []
+    for choice in control.get("choices") or []:
+        alias = " ".join(re.sub(
+            r"[^a-z0-9]+", " ", str(choice).lower()
+        ).split())
+        if alias and re.search(rf"\b{re.escape(alias)}\b", normalized):
+            requested.append(str(choice))
+    if not requested:
+        return None
+    current = [str(value) for value in (control.get("value") or [])]
+    proposed = current + [value for value in requested if value not in current]
+    cell_type = _selected_hmm_cell_type(context)
+    selected_text = ", ".join(_feature_label(value) for value in requested)
+    calls = []
+    if proposed != current:
+        calls.append({
+            "name": "set_ui_value",
+            "arguments": {"control_id": control["id"], "value": proposed},
+        })
+    return {
+        "text": (
+            f"For the currently selected cell type, **{cell_type}**, I am proposing "
+            f"the binary groups **{selected_text}**. These groups are applied after "
+            "the HMM and do not train the primary states."
+            if calls else
+            f"For **{cell_type}**, **{selected_text}** "
+            "is already selected; no change is needed."
+        ),
+        "calls": calls,
+    }
+
+
+def hmm_binary_group_guidance(
+    context: dict, messages: list[dict],
+) -> str | None:
+    """Explain live binary groups in terms of the selected cell population."""
+    controls = _hmm_feature_controls(context)
+    control = controls.get("binary_feature_groups")
+    if control is None:
+        return None
+    latest = _latest_user_message(messages).lower()
+    asks = (
+        "binary group" in latest
+        or (
+            "contact" in latest
+            and any(word in latest for word in ("important", "worth", "mean", "good"))
+        )
+    )
+    if not asks or re.search(r"\b(?:add|include|select|set)\b", latest):
+        return None
+    cell_type = _selected_hmm_cell_type(context)
+    choices = [str(value) for value in (control.get("choices") or [])]
+    if not choices:
+        return (
+            f"You currently have **{cell_type}** selected, but no binary groups are "
+            "available in its loaded feature file."
+        )
+    descriptions = "\n".join(
+        f"- **{_feature_label(choice)}**: "
+        f"{_binary_group_description(choice, cell_type)}."
+        for choice in choices
+    )
+    selected = ", ".join(
+        _feature_label(value) for value in (control.get("value") or [])
+    ) or "none"
+    contact_choices = [
+        _feature_label(choice) for choice in choices if "contact" in choice.lower()
+    ]
+    recommendation = (
+        " For target engagement, prioritize an organoid or target contact group; "
+        "a macrophage contact group can additionally test whether cells in the "
+        f"selected **{cell_type}** population behave differently while touching "
+        "macrophages."
+        if contact_choices else ""
+    )
+    return (
+        f"You currently have **{cell_type}** selected. Each binary group therefore "
+        f"describes the selected **{cell_type}** at each timepoint, not a different "
+        "population:\n"
+        f"{descriptions}\n\nCurrently selected: **{selected}**. Binary groups are "
+        f"post-HMM overlays; they do not define the primary states.{recommendation}"
+    )
+
+
+def hmm_state_merge_guidance(
+    context: dict, messages: list[dict],
+) -> str | None:
+    """Explain the supported rename-and-merge workflow for excess HMM states."""
+    if not _hmm_feature_controls(context):
+        return None
+    latest = _latest_user_message(messages).lower()
+    if not (
+        ("state" in latest or "cluster" in latest)
+        and any(phrase in latest for phrase in (
+            "which ones to keep", "select which", "too many", "merge",
+            "remove states", "drop states", "6 states", "six states",
+        ))
+    ):
+        return None
+    cell_type = _selected_hmm_cell_type(context)
+    return (
+        f"For **{cell_type}**, the HMM will first produce all requested primary "
+        "states. You do not need to rerun immediately just to discard redundant "
+        "ones. Inspect the feature heatmap, per-state distributions, and example "
+        "state bars, then use **Step 2 - Rename Primary Dynamic State Clusters**. "
+        "Give biologically equivalent clusters the **same name** to merge them into "
+        "one interpreted state.\n\nAfter that, review **Rename Full Behavioral "
+        "Clusters (Binary Groups)**. This second rename step lets you collapse the "
+        "state-plus-contact/death combinations into the final behavior labels you "
+        "want. Rerun with fewer requested states only if the primary separation "
+        "itself is unstable or uninterpretable."
+    )
+
+
 def _movement_options(context: dict) -> dict[str, list[str]]:
     controls = _hmm_feature_controls(context)
     timepoint = controls.get("timepoint_features", {})
@@ -1810,8 +2230,9 @@ def hmm_movement_feature_guidance(
     binary = ", ".join(
         _feature_label(value) for value in options["binary_available"]
     ) or "none detected"
+    cell_type = _selected_hmm_cell_type(context)
     return (
-        "The loaded T-cell feature file offers these **movement inputs**:\n\n"
+        f"The loaded **{cell_type}** feature file offers these **movement inputs**:\n\n"
         f"- Per-timepoint features: **{timepoint}**\n"
         f"- Rolling/window features: **{window}**\n\n"
         f"Currently selected: per-timepoint **{current_tp}**; window "
@@ -2228,6 +2649,17 @@ def model_tool_policy(force_bulk: bool, has_tools: bool) -> tuple[object, dict |
     return ("auto" if has_tools else None), None
 
 
+def _normalize_absent_line_value(value):
+    if value is None:
+        return "not_added"
+    normalized = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {
+        "none", "null", "n/a", "na", "absent", "not_added", "(not_added)",
+    }:
+        return "not_added"
+    return value
+
+
 def sanitize_bulk_metadata_arguments(arguments: dict, user_message: str) -> dict:
     """Drop per-sample identifiers that were not actually supplied by the user."""
     cleaned = json.loads(json.dumps(arguments or {}))
@@ -2253,12 +2685,36 @@ def sanitize_bulk_metadata_arguments(arguments: dict, user_message: str) -> dict
             sample.pop("time_unit", None)
         cell_types = sample.get("cell_types")
         if isinstance(cell_types, dict):
+            for values in cell_types.values():
+                if isinstance(values, dict) and "line" in values:
+                    values["line"] = _normalize_absent_line_value(values["line"])
             sample["cell_types"] = {
                 name: values for name, values in cell_types.items() if values
             }
             if not sample["cell_types"]:
                 sample.pop("cell_types", None)
     return cleaned
+
+
+def normalize_metadata_line_calls(calls: list[dict]) -> list[dict]:
+    """Prevent API responses from writing invalid None-like population lines."""
+    for call in calls or []:
+        name = call.get("name")
+        arguments = call.get("arguments", {}) or {}
+        if name == "set_ui_value":
+            control_id = str(arguments.get("control_id") or "")
+            if control_id.startswith("metadata.samples.") and control_id.endswith(".line"):
+                arguments["value"] = _normalize_absent_line_value(arguments.get("value"))
+        elif name == "fill_metadata_builder" and arguments.get("field") == "cell_line":
+            arguments["value"] = _normalize_absent_line_value(arguments.get("value"))
+        elif name == "bulk_fill_metadata":
+            for sample in arguments.get("samples") or []:
+                if not isinstance(sample, dict):
+                    continue
+                for values in (sample.get("cell_types") or {}).values():
+                    if isinstance(values, dict) and "line" in values:
+                        values["line"] = _normalize_absent_line_value(values["line"])
+    return calls
 
 
 def recover_single_control_action(
@@ -2416,7 +2872,8 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "deterministic shared value such as '1' and ask for confirmation. Before filling population "
         "lines, establish whether each line is shared across all samples. Filename suffixes are only "
         "proposed inferences. For a sample where a configured population is confirmed absent, set its "
-        "line to the literal value 'None'; never leave a mandatory line blank.\n"
+        "line to the literal CSV-safe value 'not_added' and describe it to the researcher as 'not "
+        "added'; never write None and never leave a mandatory line blank.\n"
         "- Use only controls matching the selected method and exact cell type. Do not apply a change to "
         "a broad cell category.\n"
         "- Navigation and read-only result/preview actions may happen immediately. Every assistant-proposed "
@@ -2553,6 +3010,10 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "- For cell counts under minimum track-length filters or at a requested timepoint, always use "
         "summarize_track_counts. Never estimate counts or calculate them from prose.\n"
         "- Behavioral State and State Trajectory are different analysis views. For HMM state classification, "
+        "read analysis.selected_cell_type before every setup, feature, or binary-group answer, explicitly "
+        "tell the researcher which cell type is selected, and interpret every contact/death group from that "
+        "selected cell's perspective. A population named in a contact group is the population the selected "
+        "cell touches; it is not evidence that the named population is selected. "
         "use fixed state count, keep Start offset at 1, use Window size 5 by default or 1 for single-frame "
         "events, and usually match Smooth window to Window size. Log-scale only inspected skewed features, do "
         "not routinely percentile-clip, and explain that binary groups are applied after the HMM. When the "
@@ -2560,13 +3021,20 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "all movement choices from both the live Timepoint features and Additional window features controls. "
         "Distinguish instantaneous/accumulated movement, directionality, and rolling trajectory summaries. "
         "Do not present the currently selected speed and net displacement as the complete option set. Ask the "
-        "researcher to choose, then propose both feature lists together rather than partially setting one.\n"
+        "researcher to choose, then propose both feature lists together rather than partially setting one. "
+        "After classification, Step 2 supports renaming primary dynamic state clusters; assigning the same "
+        "name to multiple primary clusters merges them. The subsequent full behavioral-cluster rename can "
+        "collapse state-plus-binary combinations. Never claim individual states can only be ignored or "
+        "manually edited outside BEHAV3D.\n"
         "- For State Trajectory, Trajectory size cannot exceed the Filtering trim. Average linkage is the "
         "default, Complete is a reasonable comparison, and Single performs poorly. Original BEHAV3D mode is "
         "deprecated. Be transparent that contact-based comparison plots and exemplar-track exports are known "
         "to be unreliable in the current implementation.\n"
-        "- 'Choose analysis' is an explanation request: summarize Death Dynamics, Behavioral State, and "
-        "State Trajectory and ask which biological question the researcher has; do not navigate. When the "
+        "- A general analysis-choice request must enumerate all relevant routes: Death Dynamics, Interaction "
+        "Analysis, Invasiveness Analysis, Active Killing, Behavioral State, State Trajectory, and "
+        "Backprojection. Then use the loaded metadata populations, lines/conditions, and dead-signal "
+        "availability to propose concrete biological questions and a sensible sequence, while distinguishing "
+        "configured prerequisites from results that actually exist. Do not navigate for this overview. When the "
         "user names a specific view and asks to open it, use open_analysis_view. Never repeatedly navigate "
         "to the generic Analysis tab when it is already open.\n"
         "- Produce at most the actions needed for this one user turn. There is no hidden continuation turn."
@@ -2738,6 +3206,61 @@ def assemble_tool_calls(fragments: list[dict]) -> list[dict]:
     return calls
 
 
+def deterministic_turn_response(
+    context: dict, messages: list[dict], tools: list[dict],
+) -> dict | None:
+    """Resolve feedback-critical turns before invoking the language model."""
+    deterministic_action = (
+        metadata_absence_action(context, messages)
+        or metadata_persistence_action(context, messages)
+        or metadata_time_conversion_action(context, messages)
+        or metadata_pixel_size_action(context, messages)
+        or analysis_navigation_action(context, messages)
+        or historical_reference_guidance(context, messages)
+        or apoc_feature_preset_action(context, messages)
+        or segmentation_minimum_size_action(context, messages)
+        or tracking_radius_action(context, messages)
+        or btrack_step2_action(context, messages)
+        or hmm_binary_group_action(context, messages)
+        or hmm_movement_setup_action(context, messages)
+        or active_killing_confirmation_action(context, messages)
+        or active_killing_action(context, messages)
+    )
+    available_tool_names = {tool.get("name") for tool in tools}
+    if deterministic_action and all(
+        call.get("name") in available_tool_names
+        for call in deterministic_action.get("calls", [])
+    ):
+        return deterministic_action
+
+    preflight_question = (
+        metadata_channel_mapping_guidance(context, messages)
+        or organoid_processing_question(context, messages)
+        or metadata_identifier_confirmation_question(context, messages)
+        or metadata_completion_summary(context, messages)
+        or analysis_choice_summary(context, messages)
+        or safety_profile_summary(context, messages)
+        or active_killing_readiness_summary(context, messages)
+        or feature_group_requirement_guidance(context, messages)
+        or hmm_setup_guidance(context, messages)
+        or hmm_state_merge_guidance(context, messages)
+        or hmm_binary_group_guidance(context, messages)
+        or hmm_movement_feature_guidance(context, messages)
+        or apoc_channel_selection_guidance(context, messages)
+        or apoc_feature_grid_guidance(context, messages)
+        or edt_direction_guidance(context, messages)
+        or merged_probability_watershed_guidance(context, messages)
+        or feature_threshold_guidance(context, messages)
+        or equal_track_filter_summary(context, messages)
+        or missing_log_error_question(context, messages)
+        or segmentation_signal_question(context, messages)
+        or tracking_motion_question(context, messages)
+    )
+    if preflight_question:
+        return {"text": preflight_question, "calls": []}
+    return None
+
+
 # ===========================================================================
 # Modal app (imported lazily so the pure helpers import without modal installed)
 # ===========================================================================
@@ -2857,69 +3380,23 @@ if modal is not None:
             context = body.get("context", {})
             tools = tools_for_context(body.get("tools", []), context)
 
-            deterministic_action = (
-                metadata_persistence_action(context, messages)
-                or metadata_time_conversion_action(context, messages)
-                or metadata_pixel_size_action(context, messages)
-                or analysis_navigation_action(context, messages)
-                or historical_reference_guidance(context, messages)
-                or apoc_feature_preset_action(context, messages)
-                or segmentation_minimum_size_action(context, messages)
-                or tracking_radius_action(context, messages)
-                or btrack_step2_action(context, messages)
-                or hmm_movement_setup_action(context, messages)
-                or active_killing_confirmation_action(context, messages)
-                or active_killing_action(context, messages)
+            deterministic = deterministic_turn_response(
+                context, messages, tools
             )
-            available_tool_names = {tool.get("name") for tool in tools}
-            if deterministic_action and all(
-                call.get("name") in available_tool_names
-                for call in deterministic_action.get("calls", [])
-            ):
+            if deterministic:
                 def deterministic_action_stream():
                     yield "data: " + json.dumps({
-                        "type": "token", "text": deterministic_action["text"],
+                        "type": "token", "text": deterministic["text"],
                     }) + "\n\n"
-                    if deterministic_action.get("calls"):
+                    if deterministic.get("calls"):
                         yield "data: " + json.dumps({
                             "type": "tool_calls",
-                            "calls": deterministic_action["calls"],
+                            "calls": deterministic["calls"],
                         }) + "\n\n"
                     yield "data: " + json.dumps({"type": "done"}) + "\n\n"
 
                 return StreamingResponse(
                     deterministic_action_stream(), media_type="text/event-stream"
-                )
-
-            preflight_question = (
-                metadata_channel_mapping_guidance(context, messages)
-                or organoid_processing_question(context, messages)
-                or metadata_identifier_confirmation_question(context, messages)
-                or metadata_completion_summary(context, messages)
-                or analysis_choice_summary(context, messages)
-                or safety_profile_summary(context, messages)
-                or active_killing_readiness_summary(context, messages)
-                or feature_group_requirement_guidance(context, messages)
-                or hmm_movement_feature_guidance(context, messages)
-                or apoc_channel_selection_guidance(context, messages)
-                or apoc_feature_grid_guidance(context, messages)
-                or edt_direction_guidance(context, messages)
-                or merged_probability_watershed_guidance(context, messages)
-                or feature_threshold_guidance(context, messages)
-                or equal_track_filter_summary(context, messages)
-                or missing_log_error_question(context, messages)
-                or segmentation_signal_question(context, messages)
-                or tracking_motion_question(context, messages)
-            )
-            if preflight_question:
-                def preflight_question_stream():
-                    yield "data: " + json.dumps({
-                        "type": "token", "text": preflight_question,
-                    }) + "\n\n"
-                    yield "data: " + json.dumps({"type": "done"}) + "\n\n"
-
-                return StreamingResponse(
-                    preflight_question_stream(), media_type="text/event-stream"
                 )
 
             user_msg = next((m["content"] for m in reversed(messages)
@@ -3009,6 +3486,7 @@ if modal is not None:
                             call["arguments"] = sanitize_bulk_metadata_arguments(
                                 call.get("arguments", {}), user_msg
                             )
+                calls = normalize_metadata_line_calls(calls)
                 if calls:
                     yield sse({"type": "tool_calls", "calls": calls})
                 yield sse({"type": "done"})

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-KNOWLEDGE_VERSION = "2026.07.24.23"
+KNOWLEDGE_VERSION = "2026.07.24.24"
 
 
 GUIDANCE_CARDS = {
@@ -185,7 +185,12 @@ GUIDANCE_CARDS = {
     "feature_extraction": (
         "Select feature families for the biological question. Morphology is the most expensive and "
         "should be computed only when shape matters. Movement is fast and is the default family for "
-        "motility, but is usually unnecessary for organoids. Contact distance 0 means strict mask "
+        "motility, but is usually unnecessary for organoids. The live UI makes Intensity and Contact "
+        "mandatory for every population, Movement mandatory for immune/other populations, and Death "
+        "mandatory when a dead channel is configured. Intensity includes mean dead-dye and channel "
+        "intensities, so never suggest dropping it from T cells with a configured dead channel. Only "
+        "optional groups such as Morphology and Invasiveness should be presented as removable. "
+        "Contact distance 0 means strict mask "
         "touching; increase it only when proximity should count as contact. A positive distance equal "
         "to the XY pixel size permits a one-XY-pixel gap; it is not strict touching and is not a voxel "
         "diagonal. Any contact-distance "
@@ -196,16 +201,20 @@ GUIDANCE_CARDS = {
         "requiring tracks to be recomputed."
     ),
     "active_killing": (
-        "Active Killing scores an effector against one target type per run; when there are multiple "
-        "organoid types, run each separately. Observation window counts forward from contact and must "
+        "Active Killing accepts multiple selected targets in one setup. The implementation runs each "
+        "target independently and also creates a combined analysis when more than one target is selected. "
+        "Observation window counts forward from contact and must "
         "be calibrated to expected killing delay and the metadata time interval, not copied as a "
         "universal number. Dead-mask pixel count with an absolute increase threshold is the general "
         "default. Percentage is reasonable only when target sizes are comparable; mean dye intensity "
         "is useful for diffuse reporters or when no dead-mask segmentation exists. A multiplier is "
         "reserved for a single target line or heterogeneous baselines within one well and can be "
-        "biased across target lines with different baselines. Calibrate an absolute pixel threshold "
-        "from cell size and XY pixel size, then inspect it visually; do not reuse 20-30 pixels "
-        "blindly. Minimum contact duration must reflect imaging cadence and plausible biology."
+        "biased across target lines with different baselines. Calibrate an absolute dead-mask voxel "
+        "threshold from cell size and XY and Z sampling, then inspect it visually; do not reuse 20-30 "
+        "pixels blindly. Absolute-threshold mode is incomplete while its value is 0. When the user "
+        "accepts a proposed setup, include targets, signal, threshold mode and value, observation "
+        "window, and minimum contact duration in one proposal. Minimum contact duration must reflect "
+        "imaging cadence and plausible biology."
     ),
     "filtering": (
         "Filtering must be run even when every filter is disabled: it creates the downstream CSV and "
@@ -243,7 +252,13 @@ GUIDANCE_CARDS = {
         "only after inspecting a heavily right-skewed non-negative distribution; speed is a common "
         "zero-inflated example. Do not use percentile clipping routinely because it has degraded HMM "
         "results. Binary groups are applied post hoc to split HMM motion states; they are not HMM "
-        "inputs. Use fixed state selection because automatic selection has not performed well. Keep "
+        "inputs. For movement-only analysis, enumerate all movement columns available in the live "
+        "Timepoint features control and all rolling choices in Additional window features. These can "
+        "include speed, displacement, cumulative displacement, displacement from origin, directional "
+        "persistence, turning/reversal measures, net displacement, straightness, and mean square "
+        "displacement, depending on the loaded CSV. Never imply that the two currently selected "
+        "features are the complete list; offer the available choices before changing them. Use fixed "
+        "state selection because automatic selection has not performed well. Keep "
         "Start offset at 1 so the undefined first-frame speed does not make every track begin static. "
         "Name, order, and color states from the feature heatmap and per-state distributions in "
         "behavioral_clustering_diagnostics.pdf; those labels propagate to later reports."

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-KNOWLEDGE_VERSION = "2026.07.24.24"
+KNOWLEDGE_VERSION = "2026.07.27.25"
 
 
 GUIDANCE_CARDS = {
@@ -28,7 +28,8 @@ GUIDANCE_CARDS = {
         "one movie and need separate segmentation/tracking, or should share one organoid type with "
         "line identity recorded per sample. Well and each configured population's line are mandatory; "
         "condition is optional. When no physical wells exist, propose one shared identifier such as "
-        "'1'. Use line 'None' only after absence of that population is confirmed."
+        "'1'. When a configured population is confirmed absent, describe it as not added and use "
+        "the literal CSV-safe line value 'not_added'; never use None."
     ),
     "experiment_design": (
         "Use the loaded experiment reference only for the current dataset. Preserve explicit "
@@ -230,8 +231,11 @@ GUIDANCE_CARDS = {
         "estimate the result."
     ),
     "analysis": (
-        "First identify the research question and the active analysis view. The Choose analysis action "
-        "explains the available views and must not repeatedly navigate to the Analysis tab. Open a named "
+        "First identify the research question and the active analysis view. A general analysis overview "
+        "must include Death Dynamics, Interaction Analysis, Invasiveness Analysis, Active Killing, "
+        "Behavioral State, State Trajectory, and Backprojection, then use the live metadata to suggest "
+        "dataset-specific questions and a sensible sequence. It must not repeatedly navigate to the "
+        "Analysis tab. Open a named "
         "view directly when the researcher asks. Behavioral State assigns "
         "an HMM state per timepoint. State Trajectory clusters whole trajectories using dynamic time "
         "warping. They answer different questions and their controls must not be mixed. Treat 3D "
@@ -245,7 +249,10 @@ GUIDANCE_CARDS = {
         "normalizes by elapsed time."
     ),
     "hmm": (
-        "For Behavioral State, begin with a small biologically interpretable feature set. Window size "
+        "For Behavioral State, always read and state the live selected cell type before giving setup or "
+        "binary-group advice. Interpret a contact group from the selected cell's perspective: for example, "
+        "Macrophages contact while T-cells are selected means a T-cell touching a macrophage. Begin with "
+        "a small biologically interpretable feature set. Window size "
         "5 is the default for rolling features; use 1 for genuinely single-timepoint events such as "
         "calcium peaks. Smooth window usually matches Window size and suppresses one-frame "
         "segmentation errors. Continuous features are standardized. Apply log scaling selectively "
@@ -261,7 +268,10 @@ GUIDANCE_CARDS = {
         "state selection because automatic selection has not performed well. Keep "
         "Start offset at 1 so the undefined first-frame speed does not make every track begin static. "
         "Name, order, and color states from the feature heatmap and per-state distributions in "
-        "behavioral_clustering_diagnostics.pdf; those labels propagate to later reports."
+        "behavioral_clustering_diagnostics.pdf. In Step 2, assigning the same biological name to "
+        "multiple primary clusters merges them. Then review and rename the full behavioral clusters "
+        "formed with binary groups, which can collapse unwanted state-plus-binary combinations. "
+        "Those labels propagate to later reports."
     ),
     "trajectory": (
         "State Trajectory clusters whole tracks. Trajectory size cannot exceed the trim length already "

--- a/chatbot/smoke_test.py
+++ b/chatbot/smoke_test.py
@@ -1228,6 +1228,117 @@ def _hmm_apply_all_movement_case() -> dict:
     }
 
 
+def _sam_hmm_controls() -> list[dict]:
+    prefix = "analysis.state_classification.T-cells."
+    return [
+        _control(
+            prefix + "timepoint_features",
+            "T-cells: Timepoint features",
+            ["speed"],
+            choices=["speed", "elongation"],
+            method="HMM",
+            cell_type="T-cells",
+        ),
+        _control(
+            prefix + "window_features",
+            "T-cells: Additional window features",
+            ["net_displacement"],
+            choices=["net_displacement", "straightness"],
+            method="HMM",
+            cell_type="T-cells",
+        ),
+        _control(
+            prefix + "binary_feature_groups",
+            "T-cells: Binary feature groups",
+            [],
+            choices=["Organoid_contact", "Macrophages_contact", "dead"],
+            method="HMM",
+            cell_type="T-cells",
+        ),
+        _control(
+            prefix + "n_states",
+            "T-cells: Number of states",
+            6,
+            method="HMM",
+            cell_type="T-cells",
+        ),
+    ]
+
+
+def _hmm_selected_cell_setup_case() -> dict:
+    return {
+        "name": "hmm_setup_uses_selected_tcells",
+        "messages": [{
+            "role": "user",
+            "content": (
+                "I want to do behavioral analysis, can you take me through the steps?"
+            ),
+        }],
+        "context": _context(
+            "analysis", _sam_hmm_controls(), active_cell_type="T-cells",
+            analysis={
+                "view": "behavioral_state",
+                "selected_cell_type": "T-cells",
+            },
+        ),
+        "check": _check_hmm_selected_cell_setup,
+    }
+
+
+def _hmm_macrophage_contact_for_tcells_case() -> dict:
+    return {
+        "name": "hmm_contact_meaning_uses_selected_tcells",
+        "messages": [{
+            "role": "user",
+            "content": "Would it be worth adding macrophage contact?",
+        }],
+        "context": _context(
+            "analysis", _sam_hmm_controls(), active_cell_type="T-cells",
+            analysis={
+                "view": "behavioral_state",
+                "selected_cell_type": "T-cells",
+            },
+        ),
+        "check": _check_hmm_macrophage_contact_for_tcells,
+    }
+
+
+def _hmm_add_binary_groups_for_tcells_case() -> dict:
+    return {
+        "name": "hmm_adds_binary_groups_to_selected_tcells",
+        "messages": [{
+            "role": "user",
+            "content": "Add organoid contact and also add dead",
+        }],
+        "context": _context(
+            "analysis", _sam_hmm_controls(), active_cell_type="T-cells",
+            analysis={
+                "view": "behavioral_state",
+                "selected_cell_type": "T-cells",
+            },
+        ),
+        "check": _check_hmm_add_binary_groups_for_tcells,
+    }
+
+
+def _hmm_merge_states_case() -> dict:
+    return {
+        "name": "hmm_explains_supported_state_merging",
+        "messages": [{
+            "role": "user",
+            "content": "If I have 6 states, can I select which ones to keep?",
+        }],
+        "context": _context(
+            "analysis", _sam_hmm_controls(), active_cell_type="T-cells",
+            analysis={
+                "view": "behavioral_state",
+                "selected_cell_type": "T-cells",
+            },
+        ),
+        "check": _check_hmm_merge_states,
+    }
+
+
 def _active_killing_zero_threshold_readiness_case() -> dict:
     return {
         "name": "active_killing_zero_threshold_is_not_ready",
@@ -1693,13 +1804,62 @@ def _metadata_save_case() -> dict:
 def _choose_analysis_case() -> dict:
     return {
         "name": "choose_analysis_explains_options",
-        "messages": [{"role": "user", "content": "Choose analysis"}],
+        "messages": [{
+            "role": "user",
+            "content": "Can you help me pick what analysis would be nice for my data?",
+        }],
         "context": _context(
             "analysis", [],
             assistant_session={"intent": "choose_analysis"},
             analysis={"view": "death_dynamics"},
+            metadata={
+                "loaded": True,
+                "n_samples": 8,
+                "cell_types": {
+                    "organoid": ["Organoids"],
+                    "immune": ["Macrophages", "T-cells"],
+                    "other": [],
+                },
+                "records": [{
+                    "sample_name": "Movie1",
+                    "or_Organoids_line_condition": "DO7",
+                    "im_Macrophages_line_condition": "M21",
+                    "im_T-cells_line_condition": "GD2_CART",
+                    "dead_channel": 3,
+                }],
+                "validation": [],
+            },
         ),
         "check": _check_choose_analysis,
+    }
+
+
+def _metadata_not_added_case() -> dict:
+    control_id = "metadata.samples.0.cell_types.Macrophages.line"
+    return {
+        "name": "metadata_absent_population_uses_not_added",
+        "messages": [{
+            "role": "user",
+            "content": "Macrophages were not added in Sample 1; set that line.",
+        }],
+        "context": _context(
+            "data_preparation", [
+                _control(
+                    control_id,
+                    "Sample 1, Macrophages: line",
+                    "",
+                    cell_type="Macrophages",
+                ),
+            ],
+            metadata={
+                "loaded": True,
+                "record_source": "metadata_builder_draft",
+                "records": [{"sample_name": "Sample1"}],
+                "validation": [],
+            },
+            metadata_builder={"open": True, "sample_forms_created": True},
+        ),
+        "check": _check_metadata_not_added,
     }
 
 
@@ -1737,7 +1897,10 @@ def _check_organoid_line_grouping(result: dict) -> list[str]:
 def _check_metadata_identifier_confirmation(result: dict) -> list[str]:
     text = result["text"].lower()
     errors = []
-    for phrase in ("well", "mandatory", "condition is optional", "m21/m23", "none"):
+    for phrase in (
+        "well", "mandatory", "condition is optional", "m21/m23",
+        "not added", "not_added",
+    ):
         if phrase not in text:
             errors.append(f"missing identifier guidance: {phrase}")
     if result["calls"]:
@@ -1765,7 +1928,7 @@ def _check_metadata_completion(result: dict) -> list[str]:
     errors = []
     for phrase in (
         "mandatory well", "mandatory t-cells line",
-        "mandatory macrophages line", "condition", "optional", "none",
+        "mandatory macrophages line", "condition", "optional", "not_added",
     ):
         if phrase not in text:
             errors.append(f"missing completeness detail: {phrase}")
@@ -1788,11 +1951,31 @@ def _check_metadata_save(result: dict) -> list[str]:
 def _check_choose_analysis(result: dict) -> list[str]:
     text = result["text"].lower()
     errors = []
-    for phrase in ("death dynamics", "behavioral state", "state trajectory"):
+    for phrase in (
+        "death dynamics", "interaction analysis", "invasiveness analysis",
+        "active killing", "behavioral state", "state trajectory", "backprojection",
+    ):
         if phrase not in text:
             errors.append(f"did not explain {phrase}")
+    for phrase in ("8 samples", "do7", "m21", "gd2_cart"):
+        if phrase not in text:
+            errors.append(f"did not ground the recommendation in metadata: {phrase}")
     if result["calls"]:
         errors.append("Choose analysis navigated instead of explaining options")
+    return errors
+
+
+def _check_metadata_not_added(result: dict) -> list[str]:
+    changed = _changed_values(result)
+    control_id = "metadata.samples.0.cell_types.Macrophages.line"
+    errors = []
+    if changed.get(control_id) != "not_added":
+        errors.append("did not write the CSV-safe not_added line value")
+    text = result["text"].lower()
+    if "not added" not in text or "not_added" not in text:
+        errors.append("did not explain the absent population in researcher-facing terms")
+    if re.search(r"\bline value\s+none\b", text):
+        errors.append("still recommended None as the line value")
     return errors
 
 
@@ -2466,6 +2649,63 @@ def _check_hmm_apply_all_movement(result: dict) -> list[str]:
     return errors
 
 
+def _check_hmm_selected_cell_setup(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    if "currently have **t-cells** selected" not in text:
+        errors.append("did not acknowledge the live T-cell selection")
+    for phrase in ("speed", "net displacement", "rename", "merge", "backprojection"):
+        if phrase not in text:
+            errors.append(f"missing selected-cell setup step: {phrase}")
+    if result["calls"]:
+        errors.append("changed HMM settings during an explanation-only request")
+    return errors
+
+
+def _check_hmm_macrophage_contact_for_tcells(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "currently have **t-cells** selected",
+        "a cell from t-cells is directly touching macrophages",
+        "not a different population",
+    ):
+        if phrase not in text:
+            errors.append(f"missing selected-cell contact meaning: {phrase}")
+    if result["calls"]:
+        errors.append("changed binary groups before the researcher requested an edit")
+    return errors
+
+
+def _check_hmm_add_binary_groups_for_tcells(result: dict) -> list[str]:
+    changed = _changed_values(result)
+    control_id = "analysis.state_classification.T-cells.binary_feature_groups"
+    errors = []
+    if changed.get(control_id) != ["Organoid_contact", "dead"]:
+        errors.append("did not update the selected T-cell binary-group control")
+    if "t-cells" not in result["text"].lower():
+        errors.append("did not identify the selected T-cell population")
+    return errors
+
+
+def _check_hmm_merge_states(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "rename primary dynamic state clusters", "same name", "merge",
+        "full behavioral clusters",
+    ):
+        if phrase not in text:
+            errors.append(f"missing supported state-merge guidance: {phrase}")
+    if any(phrase in text for phrase in (
+        "not a built-in feature", "outside behav3d", "ignore ones",
+    )):
+        errors.append("claimed BEHAV3D cannot merge states")
+    if result["calls"]:
+        errors.append("changed HMM settings during a workflow explanation")
+    return errors
+
+
 def _check_active_killing_zero_threshold_readiness(result: dict) -> list[str]:
     text = result["text"].lower()
     errors = []
@@ -2619,6 +2859,7 @@ SCENARIOS = [
     _metadata_completion_case,
     _metadata_save_case,
     _choose_analysis_case,
+    _metadata_not_added_case,
     _open_death_dynamics_case,
     _metadata_setup_case,
     _pixel_fill_case,
@@ -2655,6 +2896,10 @@ SCENARIOS = [
     _active_killing_complete_acceptance_case,
     _hmm_movement_options_case,
     _hmm_apply_all_movement_case,
+    _hmm_selected_cell_setup_case,
+    _hmm_macrophage_contact_for_tcells_case,
+    _hmm_add_binary_groups_for_tcells_case,
+    _hmm_merge_states_case,
     _active_killing_zero_threshold_readiness_case,
     _hmm_single_frame_case,
     _trajectory_linkage_case,

--- a/chatbot/smoke_test.py
+++ b/chatbot/smoke_test.py
@@ -35,8 +35,10 @@ def _control(
     unit: str | None = None,
     visible: bool = True,
     enabled: bool = True,
+    required_choices: list[str] | None = None,
+    active: bool | None = None,
 ) -> dict:
-    return {
+    control = {
         "id": control_id,
         "label": label,
         "value": value,
@@ -48,6 +50,11 @@ def _control(
         "cell_type": cell_type,
         "unit": unit,
     }
+    if required_choices is not None:
+        control["required_choices"] = required_choices
+    if active is not None:
+        control["active"] = active
+    return control
 
 
 def _metadata_records() -> list[dict]:
@@ -999,6 +1006,15 @@ def _active_killing_case() -> dict:
             method="Active Killing",
             cell_type="tcell",
         ),
+        _control(
+            "features.active_killing.absolute_threshold",
+            "Active Killing: Absolute signal-increase threshold",
+            0.0,
+            unit="pixels",
+            method="Active Killing",
+            cell_type="tcell",
+            active=False,
+        ),
     ]
     metadata = {
         "loaded": True,
@@ -1017,8 +1033,8 @@ def _active_killing_case() -> dict:
             "role": "user",
             "content": (
                 "Configure active killing for tcell against organoid1 only. I expect "
-                "killing within 10 minutes and images are every 2 minutes. Use the "
-                "generally recommended death signal and threshold mode."
+                "killing within 10 minutes and images are every 2 minutes. Use an "
+                "absolute threshold of 30 dead pixels."
             ),
         }],
         "context": _context(
@@ -1027,6 +1043,211 @@ def _active_killing_case() -> dict:
             feature_extraction={"active_killing_open": True},
         ),
         "check": _check_active_killing,
+    }
+
+
+def _feature_group_dead_dye_case() -> dict:
+    choices = [
+        "movement", "intensity", "morphology", "contact",
+        "invasiveness", "death",
+    ]
+    controls = [_control(
+        "features.tcell.feature_groups",
+        "tcell: feature groups",
+        choices,
+        choices=choices,
+        cell_type="tcell",
+        required_choices=["movement", "intensity", "contact", "death"],
+    )]
+    return {
+        "name": "tcell_features_keep_dead_dye_intensity",
+        "messages": [{
+            "role": "user",
+            "content": "Now adjust T cells. Should I drop intensity?",
+        }],
+        "context": _context(
+            "feature_extraction", controls, active_cell_type="tcell",
+        ),
+        "check": _check_feature_group_dead_dye,
+    }
+
+
+def _active_killing_complete_acceptance_case() -> dict:
+    controls = [
+        _control(
+            "features.active_killing.target_types",
+            "Active Killing: Target cell type",
+            ["27t", "mdo"],
+            choices=["27t", "mdo"],
+            method="Active Killing",
+            cell_type="tcell",
+        ),
+        _control(
+            "features.active_killing.observation_window",
+            "Active Killing: Observation window",
+            5,
+            unit="timepoints",
+            method="Active Killing",
+            cell_type="tcell",
+        ),
+        _control(
+            "features.active_killing.death_signal",
+            "Active Killing: Death or reporter signal",
+            "Dead-mask percentage",
+            choices=[
+                "Dead-mask percentage", "Mean dead-dye intensity",
+                "Dead-mask pixel count",
+            ],
+            method="Active Killing",
+            cell_type="tcell",
+        ),
+        _control(
+            "features.active_killing.use_absolute_threshold",
+            "Active Killing: Use an absolute signal-increase threshold",
+            False,
+            method="Active Killing",
+            cell_type="tcell",
+        ),
+        _control(
+            "features.active_killing.absolute_threshold",
+            "Active Killing: Absolute signal-increase threshold",
+            0.0,
+            unit="pixels",
+            method="Active Killing",
+            cell_type="tcell",
+            active=False,
+        ),
+        _control(
+            "features.active_killing.minimum_contact_duration",
+            "Active Killing: Minimum contact duration",
+            1,
+            unit="timepoints",
+            method="Active Killing",
+            cell_type="tcell",
+        ),
+    ]
+    return {
+        "name": "active_killing_accepts_complete_setup",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": (
+                    "Active Killing configuration for tcell against 27t and mdo: "
+                    "Death signal: Dead-mask pixel count. Absolute threshold: "
+                    "30 dead pixels. Observation window: 5 timepoints. "
+                    "Minimum contact duration: 1 frame."
+                ),
+            },
+            {"role": "user", "content": "Ok, these settings seem ok"},
+        ],
+        "context": _context(
+            "feature_extraction", controls, active_cell_type="tcell",
+            feature_extraction={
+                "active_killing_open": True,
+                "active_killing": {
+                    "setup_ready": True,
+                    "setup_issues": [],
+                },
+            },
+        ),
+        "check": _check_active_killing_complete_acceptance,
+    }
+
+
+def _hmm_movement_controls() -> list[dict]:
+    prefix = "analysis.state_classification.tcell."
+    return [
+        _control(
+            prefix + "timepoint_features",
+            "tcell: Timepoint features",
+            ["speed"],
+            choices=[
+                "speed", "displacement", "cumulative_displacement",
+                "displacement_from_origin", "directional_persistence",
+                "median_turning_angle", "mean_dead_dye",
+            ],
+            method="HMM",
+            cell_type="tcell",
+        ),
+        _control(
+            prefix + "window_features",
+            "tcell: Additional window features",
+            ["net_displacement"],
+            choices=[
+                "net_displacement", "straightness",
+                "mean_square_displacement",
+            ],
+            method="HMM",
+            cell_type="tcell",
+        ),
+        _control(
+            prefix + "binary_feature_groups",
+            "tcell: Binary feature groups",
+            ["27t_contact", "mdo_contact"],
+            choices=["27t_contact", "mdo_contact"],
+            method="HMM",
+            cell_type="tcell",
+        ),
+    ]
+
+
+def _hmm_movement_options_case() -> dict:
+    controls = _hmm_movement_controls()
+    return {
+        "name": "hmm_lists_all_movement_options",
+        "messages": [{
+            "role": "user",
+            "content": "Only movement features of relevance",
+        }],
+        "context": _context(
+            "analysis", controls, active_cell_type="tcell",
+            analysis={"view": "behavioral_state", "selected_cell_type": "tcell"},
+        ),
+        "check": _check_hmm_movement_options,
+    }
+
+
+def _hmm_apply_all_movement_case() -> dict:
+    return {
+        "name": "hmm_applies_all_offered_movement_features",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": (
+                    "Choose the feature names you want, or say use all available "
+                    "movement features."
+                ),
+            },
+            {"role": "user", "content": "Use all available movement features"},
+        ],
+        "context": _context(
+            "analysis", _hmm_movement_controls(), active_cell_type="tcell",
+            analysis={"view": "behavioral_state", "selected_cell_type": "tcell"},
+        ),
+        "check": _check_hmm_apply_all_movement,
+    }
+
+
+def _active_killing_zero_threshold_readiness_case() -> dict:
+    return {
+        "name": "active_killing_zero_threshold_is_not_ready",
+        "messages": [
+            {"role": "assistant", "content": "Active Killing setup"},
+            {"role": "user", "content": "Is it ready?"},
+        ],
+        "context": _context(
+            "feature_extraction", [], active_cell_type="tcell",
+            feature_extraction={
+                "active_killing_open": True,
+                "active_killing": {
+                    "setup_ready": False,
+                    "setup_issues": [
+                        "Absolute signal-increase threshold must be greater than 0."
+                    ],
+                },
+            },
+        ),
+        "check": _check_active_killing_zero_threshold_readiness,
     }
 
 
@@ -2140,6 +2361,7 @@ def _check_active_killing(result: dict) -> list[str]:
         "features.active_killing.observation_window": 5,
         "features.active_killing.death_signal": "Dead-mask pixel count",
         "features.active_killing.use_absolute_threshold": True,
+        "features.active_killing.absolute_threshold": 30,
     }
     errors = []
     for control_id, value in expected.items():
@@ -2156,6 +2378,101 @@ def _check_active_killing(result: dict) -> list[str]:
         "i've set", "i have set", "changes are applied", "changes were applied",
     )):
         errors.append("claimed proposed Active Killing changes were already applied")
+    return errors
+
+
+def _check_feature_group_dead_dye(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "required", "intensity", "mean dead-dye intensity",
+        "will not suggest removing",
+    ):
+        if phrase not in text:
+            errors.append(f"missing mandatory feature guidance: {phrase}")
+    if "drop intensity" in text or "remove intensity" in text:
+        errors.append("still suggested removing required T-cell intensity")
+    if result["calls"]:
+        errors.append("changed feature groups before the optional-group choice")
+    return errors
+
+
+def _check_active_killing_complete_acceptance(result: dict) -> list[str]:
+    changed = _changed_values(result)
+    expected = {
+        "features.active_killing.target_types": ["27t", "mdo"],
+        "features.active_killing.observation_window": 5,
+        "features.active_killing.death_signal": "Dead-mask pixel count",
+        "features.active_killing.use_absolute_threshold": True,
+        "features.active_killing.absolute_threshold": 30,
+        "features.active_killing.minimum_contact_duration": 1,
+    }
+    errors = []
+    for control_id, value in expected.items():
+        if changed.get(control_id) != value:
+            errors.append(
+                f"{control_id} was {changed.get(control_id)!r}, expected {value!r}"
+            )
+    text = result["text"].lower()
+    for phrase in (
+        "complete agreed active killing setup",
+        "independently",
+        "combined analysis",
+        "not ready until every action card",
+    ):
+        if phrase not in text:
+            errors.append(f"missing setup-completeness guidance: {phrase}")
+    return errors
+
+
+def _check_hmm_movement_options(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "speed", "displacement", "cumulative displacement",
+        "displacement from origin", "directional persistence",
+        "median turning angle", "net displacement", "straightness",
+        "mean square displacement", "use all available movement features",
+    ):
+        if phrase not in text:
+            errors.append(f"missing movement option: {phrase}")
+    if "mean dead dye" in text:
+        errors.append("included a non-movement intensity feature")
+    if result["calls"]:
+        errors.append("changed HMM inputs before the researcher chose features")
+    return errors
+
+
+def _check_hmm_apply_all_movement(result: dict) -> list[str]:
+    changed = _changed_values(result)
+    prefix = "analysis.state_classification.tcell."
+    errors = []
+    expected_timepoint = [
+        "speed", "displacement", "cumulative_displacement",
+        "displacement_from_origin", "directional_persistence",
+        "median_turning_angle",
+    ]
+    expected_window = [
+        "net_displacement", "straightness", "mean_square_displacement",
+    ]
+    if changed.get(prefix + "timepoint_features") != expected_timepoint:
+        errors.append("did not propose all offered timepoint movement features")
+    if changed.get(prefix + "window_features") != expected_window:
+        errors.append("did not propose all offered window movement features")
+    if "mean_dead_dye" in str(changed):
+        errors.append("included a non-movement intensity feature")
+    if "complete movement-only selection" not in result["text"].lower():
+        errors.append("did not describe the two-list selection as complete")
+    return errors
+
+
+def _check_active_killing_zero_threshold_readiness(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    if "not ready yet" not in text or "greater than 0" not in text:
+        errors.append("did not report the zero absolute threshold as incomplete")
+    if result["calls"]:
+        errors.append("attempted another partial edit instead of reporting readiness")
     return errors
 
 
@@ -2334,6 +2651,11 @@ SCENARIOS = [
     _filtering_case,
     _reporter_propagation_case,
     _active_killing_case,
+    _feature_group_dead_dye_case,
+    _active_killing_complete_acceptance_case,
+    _hmm_movement_options_case,
+    _hmm_apply_all_movement_case,
+    _active_killing_zero_threshold_readiness_case,
     _hmm_single_frame_case,
     _trajectory_linkage_case,
     _functional_experiment_context_case,

--- a/test/fixtures/assistant_feedback_transcripts.json
+++ b/test/fixtures/assistant_feedback_transcripts.json
@@ -107,16 +107,44 @@
     ]
   },
   {
+    "id": "feature_mandatory_dead_dye",
+    "step": "feature_extraction",
+    "user": "Can I drop intensity from the T-cell feature groups?",
+    "required": [
+      "intensity and contact mandatory",
+      "death mandatory when a dead channel is configured",
+      "mean dead-dye",
+      "never suggest dropping it"
+    ]
+  },
+  {
     "id": "active_killing_calibration",
     "step": "feature_extraction",
     "user": "How should I choose the active killing window and threshold?",
     "required": [
-      "one target type per run",
+      "multiple selected targets",
+      "runs each target independently",
+      "combined analysis",
       "metadata time interval",
       "dead-mask pixel count",
       "absolute increase threshold",
+      "incomplete while its value is 0",
       "do not reuse 20-30 pixels blindly",
       "minimum contact duration"
+    ]
+  },
+  {
+    "id": "hmm_movement_options",
+    "step": "analysis",
+    "user": "For Behavioral State, which movement features can I choose?",
+    "required": [
+      "enumerate all movement columns",
+      "timepoint features",
+      "additional window features",
+      "speed",
+      "directional persistence",
+      "straightness",
+      "never imply that the two currently selected features are the complete list"
     ]
   },
   {

--- a/test/fixtures/assistant_feedback_transcripts.json
+++ b/test/fixtures/assistant_feedback_transcripts.json
@@ -265,7 +265,7 @@
     "required": [
       "well and each configured population's line are mandatory",
       "condition is optional",
-      "line 'none'"
+      "line value 'not_added'"
     ]
   },
   {
@@ -273,9 +273,13 @@
     "step": "analysis",
     "user": "Choose analysis",
     "required": [
-      "choose analysis action explains",
-      "must not repeatedly navigate",
-      "open a named view directly"
+      "death dynamics",
+      "interaction analysis",
+      "invasiveness analysis",
+      "active killing",
+      "behavioral state",
+      "state trajectory",
+      "backprojection"
     ]
   },
   {
@@ -364,6 +368,34 @@
       "start at 50%",
       "xy pixel size squared times z pixel size",
       "preview value"
+    ]
+  },
+  {
+    "id": "hmm_selected_cell_type_controls_contact_meaning",
+    "step": "analysis",
+    "user": "Would macrophage contact be useful as an HMM binary group while T-cells are selected?",
+    "required": [
+      "always read and state the live selected cell type",
+      "macrophages contact while t-cells are selected means a t-cell touching a macrophage"
+    ]
+  },
+  {
+    "id": "hmm_states_can_be_merged_in_step_two",
+    "step": "analysis",
+    "user": "If I have six HMM states, can I merge the ones I do not want?",
+    "required": [
+      "assigning the same biological name to multiple primary clusters merges them",
+      "full behavioral clusters"
+    ]
+  },
+  {
+    "id": "metadata_absence_uses_csv_safe_value",
+    "step": "data_preparation",
+    "user": "There were no macrophages in this sample.",
+    "required": [
+      "describe it as not added",
+      "line value 'not_added'",
+      "never use none"
     ]
   }
 ]

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -25,7 +25,7 @@ from behav3d.napari._assistant_context import (
     summarize_metadata, _diff_from_defaults, validate_metadata_records,
     _metadata_builder_state, _experiment_reference_context,
     _image_dimensions_state, _current_log_state, _segmentation_state,
-    _interface_capabilities, build_context,
+    _interface_capabilities, _feature_extraction_state, build_context,
 )
 from behav3d.napari._assistant_controls import (
     CONTROL_CONTRACT_VERSION, active_cell_type, control_registry,
@@ -711,6 +711,7 @@ def test_active_killing_action_is_cadence_grounded_and_explicitly_proposed():
             "features.active_killing.observation_window",
             "features.active_killing.death_signal",
             "features.active_killing.use_absolute_threshold",
+            "features.active_killing.absolute_threshold",
         )
     ]
     result = app.active_killing_action(
@@ -723,7 +724,8 @@ def test_active_killing_action_is_cadence_grounded_and_explicitly_proposed():
         },
         [{"role": "user", "content": (
             "Configure active killing for tcell against organoid1 only. "
-            "I expect killing within 10 minutes."
+            "I expect killing within 10 minutes. "
+            "Use an absolute threshold of 30 dead pixels."
         )}],
     )
     values = {
@@ -734,8 +736,222 @@ def test_active_killing_action_is_cadence_grounded_and_explicitly_proposed():
     assert values["features.active_killing.observation_window"] == 5
     assert values["features.active_killing.death_signal"] == "Dead-mask pixel count"
     assert values["features.active_killing.use_absolute_threshold"] is True
+    assert values["features.active_killing.absolute_threshold"] == 30
     assert "proposing" in result["text"]
     assert "require your confirmation" in result["text"]
+
+
+def test_active_killing_action_refuses_incomplete_absolute_mode():
+    import app
+
+    result = app.active_killing_action(
+        {
+            "current_step": "feature_extraction",
+            "metadata": {"records": [{
+                "time_interval": 2, "time_unit": "min",
+            }]},
+            "ui_state": {"controls": []},
+        },
+        [{"role": "user", "content": (
+            "Configure active killing against 27t and mdo within 10 minutes."
+        )}],
+    )
+    assert result["calls"] == []
+    assert "positive minimum dead-mask pixel increase" in result["text"]
+    assert "remains 0" in result["text"]
+
+
+def test_active_killing_acceptance_proposes_every_agreed_field():
+    import app
+
+    controls = []
+    specs = {
+        "target_types": {
+            "value": ["27t", "mdo"], "choices": ["27t", "mdo"],
+        },
+        "observation_window": {"value": 5},
+        "death_signal": {
+            "value": "Dead-mask percentage",
+            "choices": [
+                "Dead-mask percentage", "Mean dead-dye intensity",
+                "Dead-mask pixel count",
+            ],
+        },
+        "use_absolute_threshold": {"value": False},
+        "absolute_threshold": {"value": 0.0, "active": False},
+        "minimum_contact_duration": {"value": 1},
+    }
+    for suffix, values in specs.items():
+        controls.append({
+            "id": f"features.active_killing.{suffix}",
+            "visible": True,
+            "enabled": True,
+            **values,
+        })
+    result = app.active_killing_confirmation_action(
+        {
+            "current_step": "feature_extraction",
+            "ui_state": {"controls": controls},
+        },
+        [
+            {"role": "assistant", "content": (
+                "Active Killing configuration for tcell against 27t and mdo: "
+                "Death signal: Dead-mask pixel count. Absolute threshold: "
+                "30 dead pixels. Observation window: 5 timepoints. "
+                "Minimum contact duration: 1 frame."
+            )},
+            {"role": "user", "content": "Ok, these settings seem ok"},
+        ],
+    )
+    values = {
+        call["arguments"]["control_id"]: call["arguments"]["value"]
+        for call in result["calls"]
+    }
+    assert values["features.active_killing.target_types"] == ["27t", "mdo"]
+    assert values["features.active_killing.death_signal"] == "Dead-mask pixel count"
+    assert values["features.active_killing.use_absolute_threshold"] is True
+    assert values["features.active_killing.absolute_threshold"] == 30
+    assert values["features.active_killing.observation_window"] == 5
+    assert values["features.active_killing.minimum_contact_duration"] == 1
+    assert "complete agreed Active Killing setup" in result["text"]
+    assert "independently" in result["text"]
+    assert "not ready until every action card" in result["text"]
+
+
+def test_active_killing_readiness_rejects_zero_absolute_threshold():
+    import app
+
+    summary = app.active_killing_readiness_summary(
+        {
+            "current_step": "feature_extraction",
+            "feature_extraction": {"active_killing": {
+                "setup_ready": False,
+                "setup_issues": [
+                    "Absolute signal-increase threshold must be greater than 0."
+                ],
+            }},
+        },
+        [
+            {"role": "assistant", "content": "Active Killing setup"},
+            {"role": "user", "content": "Is it ready?"},
+        ],
+    )
+    assert "not ready yet" in summary
+    assert "greater than 0" in summary
+
+
+def test_hmm_movement_guidance_lists_every_live_option_before_editing():
+    import app
+
+    prefix = "analysis.state_classification.tcell."
+    context = {
+        "current_step": "analysis",
+        "analysis": {
+            "view": "behavioral_state",
+            "selected_cell_type": "tcell",
+        },
+        "ui_state": {"controls": [
+            {
+                "id": prefix + "timepoint_features",
+                "visible": True,
+                "enabled": True,
+                "choices": [
+                    "speed", "displacement", "cumulative_displacement",
+                    "directional_persistence", "mean_dead_dye",
+                ],
+                "value": ["speed"],
+            },
+            {
+                "id": prefix + "window_features",
+                "visible": True,
+                "enabled": True,
+                "choices": [
+                    "net_displacement", "straightness",
+                    "mean_square_displacement",
+                ],
+                "value": ["net_displacement"],
+            },
+            {
+                "id": prefix + "binary_feature_groups",
+                "visible": True,
+                "enabled": True,
+                "choices": ["27t_contact", "mdo_contact"],
+                "value": ["27t_contact", "mdo_contact"],
+            },
+        ]},
+    }
+    text = app.hmm_movement_feature_guidance(
+        context,
+        [{"role": "user", "content": "Only movement features of relevance"}],
+    )
+    for label in (
+        "Speed", "Displacement", "Cumulative displacement",
+        "Directional persistence", "Net displacement", "Straightness",
+        "Mean square displacement",
+    ):
+        assert label in text
+    assert "Mean dead dye" not in text
+    assert "use all available movement features" in text
+    assert "applied after the HMM" in text
+
+
+def test_hmm_all_movement_choice_updates_both_feature_lists():
+    import app
+
+    prefix = "analysis.state_classification.tcell."
+    context = {
+        "current_step": "analysis",
+        "analysis": {
+            "view": "behavioral_state",
+            "selected_cell_type": "tcell",
+        },
+        "ui_state": {"controls": [
+            {
+                "id": prefix + "timepoint_features",
+                "visible": True,
+                "enabled": True,
+                "choices": [
+                    "speed", "displacement", "directional_persistence",
+                    "mean_dead_dye",
+                ],
+                "value": ["speed"],
+            },
+            {
+                "id": prefix + "window_features",
+                "visible": True,
+                "enabled": True,
+                "choices": ["net_displacement", "straightness"],
+                "value": ["net_displacement"],
+            },
+            {
+                "id": prefix + "binary_feature_groups",
+                "visible": True,
+                "enabled": True,
+                "choices": ["27t_contact", "mdo_contact"],
+                "value": ["27t_contact", "mdo_contact"],
+            },
+        ]},
+    }
+    result = app.hmm_movement_setup_action(
+        context,
+        [
+            {"role": "assistant", "content": (
+                "Choose names or say use all available movement features."
+            )},
+            {"role": "user", "content": "Use all available movement features"},
+        ],
+    )
+    values = {
+        call["arguments"]["control_id"]: call["arguments"]["value"]
+        for call in result["calls"]
+    }
+    assert values[prefix + "timepoint_features"] == [
+        "speed", "displacement", "directional_persistence",
+    ]
+    assert values[prefix + "window_features"] == [
+        "net_displacement", "straightness",
+    ]
+    assert "mean_dead_dye" not in str(values)
 
 
 def test_equal_track_filter_review_explains_valid_fixed_length_workflow():
@@ -1213,6 +1429,7 @@ def test_safety_profile_summary_preserves_reference_without_claiming_execution()
     assert "tumor 27T and healthy MDO" in summary
     assert "5 frames (10 minutes)" in summary
     assert "not a completed analysis" in summary
+    assert "independent analysis for each target plus a combined analysis" in summary
     assert "configured" not in summary.lower()
 
 
@@ -1676,6 +1893,13 @@ def test_prompt_encodes_pi_feedback_scenarios():
     assert "does not mean APOC uses all channels" in sp
     assert "'Tune Features' means the classifier feature preset" in sp
     assert "ask them to copy and paste the latest error lines" in sp
+    assert "Intensity and Contact are required for every cell type" in sp
+    assert "never suggest dropping it from a T-cell population" in sp
+    assert "automatically produces an independent analysis" in sp
+    assert "Never apply only the mode checkbox" in sp
+    assert "setup_ready true" in sp
+    assert "enumerate all movement choices" in sp
+    assert "currently selected speed and net displacement" in sp
 
 
 class _FakeSpin:
@@ -1693,10 +1917,12 @@ class _FakeSpin:
 
 
 class _FakeCheck:
-    def __init__(self, checked=False): self._checked = checked
+    def __init__(self, checked=False, enabled=True):
+        self._checked = checked
+        self._enabled = enabled
     def isChecked(self): return self._checked
     def setChecked(self, value): self._checked = bool(value)
-    def isEnabled(self): return True
+    def isEnabled(self): return self._enabled
     def isHidden(self): return False
 
 
@@ -2122,7 +2348,7 @@ def test_live_registry_covers_filtering_and_hmm_controls():
     assert controls[states]["visible"] is True
 
 
-def test_active_killing_registry_targets_one_selected_type():
+def test_active_killing_registry_keeps_dependent_threshold_editable():
     from types import SimpleNamespace
     active = SimpleNamespace(
         immune_combo=_FakeCombo(["tcell"]),
@@ -2157,9 +2383,124 @@ def test_active_killing_registry_targets_one_selected_type():
     assert apply_set_ui_value(main, signal_id, "Dead-mask pixel count")
     assert active.death_signal_combo.currentText() == "nr_dead_mask_pixels"
     assert apply_set_ui_value(main, target_id, ["organoid2"])
-    assert controls["features.active_killing.absolute_threshold"]["visible"] is False
+    threshold = controls["features.active_killing.absolute_threshold"]
+    assert threshold["visible"] is True
+    assert threshold["enabled"] is True
+    assert threshold["active"] is False
+    assert apply_set_ui_value(
+        main, "features.active_killing.absolute_threshold", 30.0
+    )
+    assert active.spin_abs_threshold.value() == 30.0
     assert active_cell_type(main, "feature_extraction") == "tcell"
     assert [item.text() for item in active.target_list.selectedItems()] == ["organoid2"]
+
+
+def test_feature_context_reports_active_killing_setup_readiness():
+    from types import SimpleNamespace
+
+    active = SimpleNamespace(
+        immune_combo=_FakeCombo(["tcell"]),
+        target_list=_FakeList(["27t", "mdo"], selected=["27t", "mdo"]),
+        spin_obs_window=_FakeSpin(5),
+        death_signal_combo=_FakeCombo([
+            "percentage_dead_mask", "mean_dead_dye", "nr_dead_mask_pixels",
+        ], 2),
+        check_abs_threshold=_FakeCheck(True),
+        spin_threshold_mult=_FakeSpin(1.5),
+        spin_abs_threshold=_FakeSpin(0.0),
+        spin_min_contact=_FakeSpin(1),
+    )
+    main = SimpleNamespace(feature_extraction_tab=SimpleNamespace(
+        active_killing_panel=active,
+        _ak_toggle_btn=_FakeCheck(True),
+    ))
+    state = _feature_extraction_state(main)["active_killing"]
+    assert state["setup_ready"] is False
+    assert "greater than 0" in state["setup_issues"][0]
+    active.spin_abs_threshold.setValue(30.0)
+    state = _feature_extraction_state(main)["active_killing"]
+    assert state["setup_ready"] is True
+    assert state["setup_issues"] == []
+
+
+def test_feature_registry_marks_and_preserves_mandatory_groups():
+    from types import SimpleNamespace
+
+    checks = {
+        "movement": _FakeCheck(True, enabled=False),
+        "intensity": _FakeCheck(True, enabled=False),
+        "morphology": _FakeCheck(True),
+        "contact": _FakeCheck(True, enabled=False),
+        "invasiveness": _FakeCheck(True),
+        "death": _FakeCheck(True, enabled=False),
+    }
+    panel = SimpleNamespace(
+        feature_checks=checks,
+        contact_threshold=_FakeSpin(0.0),
+        spin_dead_threshold=_FakeSpin(5.0),
+        spin_workers=_FakeSpin(1),
+        _persist=lambda: None,
+    )
+    main = SimpleNamespace(feature_extraction_tab=SimpleNamespace(
+        panels={"tcell": panel},
+        active_killing_panel=None,
+    ))
+    control = next(
+        item for item in control_registry(main)
+        if item["id"] == "features.tcell.feature_groups"
+    )
+    assert control["required_choices"] == [
+        "movement", "intensity", "contact", "death",
+    ]
+    assert control["editable_choices"] == ["morphology", "invasiveness"]
+
+    action = build_actions(
+        [{
+            "name": "set_ui_value",
+            "arguments": {
+                "control_id": control["id"],
+                "value": ["movement", "contact", "death"],
+            },
+        }],
+        cards=[],
+        params={},
+        controls=[control],
+    )[0]
+    assert action.ok is False
+    assert "must keep:" in action.message
+    assert "intensity" in action.message
+
+
+def test_feature_group_guidance_keeps_intensity_for_dead_dye():
+    import app
+
+    text = app.feature_group_requirement_guidance(
+        {
+            "current_step": "feature_extraction",
+            "active_cell_type": "tcell",
+            "ui_state": {"controls": [{
+                "id": "features.tcell.feature_groups",
+                "visible": True,
+                "enabled": True,
+                "choices": [
+                    "movement", "intensity", "morphology", "contact",
+                    "invasiveness", "death",
+                ],
+                "required_choices": [
+                    "movement", "intensity", "contact", "death",
+                ],
+                "value": [
+                    "movement", "intensity", "morphology", "contact",
+                    "invasiveness", "death",
+                ],
+            }]},
+        },
+        [{"role": "user", "content": "Now adjust T cells"}],
+    )
+    assert "Intensity" in text
+    assert "mean dead-dye intensity" in text
+    assert "will not suggest removing" in text
+    assert "Morphology, Invasiveness" in text
 
 
 def test_analysis_registry_exposes_only_active_trajectory_controls():
@@ -2567,7 +2908,7 @@ def test_feedback_guidance_fixtures():
 
     fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
     cases = json.loads(fixture.read_text(encoding="utf-8"))
-    assert KNOWLEDGE_VERSION == "2026.07.24.23"
+    assert KNOWLEDGE_VERSION == "2026.07.24.24"
     for case in cases:
         cards = select_guidance_cards(
             {"current_step": case["step"]}, case["user"], case.get("intent"))
@@ -2601,7 +2942,7 @@ def test_assistant_has_no_hidden_model_continuation():
     assert "def _auto_continue" not in source
     assert "_dispatch_proactive" not in source
     assert "Checking your setup" not in source
-    assert CONTROL_CONTRACT_VERSION == "3.1"
+    assert CONTROL_CONTRACT_VERSION == "3.2"
 
 
 # --------------------------------------------------------------------------

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -19,7 +19,7 @@ from behav3d.napari._assistant_schema import (
 )
 from behav3d.napari._assistant_actions import (
     ProposedAction, get_by_dotted, set_by_dotted, validate_value, build_actions,
-    apply_action, apply_set_ui_value,
+    apply_action, apply_set_ui_value, normalize_metadata_line_value,
 )
 from behav3d.napari._assistant_context import (
     summarize_metadata, _diff_from_defaults, validate_metadata_records,
@@ -33,7 +33,9 @@ from behav3d.napari._assistant_controls import (
 from behav3d.napari._assistant_recommendations import (
     calculate_edt_recommendations, format_edt_recommendations,
 )
-from behav3d.napari._assistant import researcher_facing_text
+from behav3d.napari._assistant import (
+    researcher_facing_text, streaming_transcript_block, transcript_block_role,
+)
 from behav3d.analysis.track_counts import (
     calculate_track_count_table, format_track_count_summary,
     generate_track_count_summary,
@@ -329,6 +331,13 @@ def test_backend_hides_bulk_metadata_tool_after_forms_exist():
     assert sanitized == {"samples": [{
         "pixel_distance_xy": 1.15, "pixel_distance_z": 4, "time_interval": 15,
     }]}
+    absent = app.sanitize_bulk_metadata_arguments({"samples": [{
+        "cell_types": {
+            "T cells": {"line": "GD2_CART"},
+            "Macrophages": {"line": None},
+        },
+    }]}, "T cells are GD2_CART and macrophages were not added")
+    assert absent["samples"][0]["cell_types"]["Macrophages"]["line"] == "not_added"
     recovered = app.recover_single_control_action(
         [],
         {"ui_state": {"controls": [{
@@ -501,7 +510,8 @@ def test_metadata_identifier_inferences_require_confirmation():
     assert "mandatory" in response
     assert "condition is optional" in response
     assert "M21/M23" in response
-    assert "None" in response
+    assert "not_added" in response
+    assert "not added" in response
     assert "confirm" in response
 
 
@@ -562,12 +572,33 @@ def test_analysis_choose_explains_and_named_view_opens_directly():
     import app
 
     summary = app.analysis_choice_summary(
-        {"assistant_session": {"intent": "choose_analysis"}},
-        [{"role": "user", "content": "Choose analysis"}],
+        {
+            "assistant_session": {"intent": "choose_analysis"},
+            "metadata": {
+                "n_samples": 8,
+                "cell_types": {
+                    "organoid": ["Organoids"],
+                    "immune": ["Macrophages", "T-cells"],
+                    "other": [],
+                },
+                "records": [{
+                    "or_Organoids_line_condition": "DO7",
+                    "im_T-cells_line_condition": "GD2_CART",
+                    "im_Macrophages_line_condition": "M21",
+                    "dead_channel": 3,
+                }],
+            },
+        },
+        [{"role": "user", "content": "Can you help me pick what analysis is nice?"}],
     )
-    assert "Death Dynamics" in summary
-    assert "Behavioral State" in summary
-    assert "State Trajectory" in summary
+    for name in (
+        "Death Dynamics", "Interaction Analysis", "Invasiveness Analysis",
+        "Active Killing", "Behavioral State", "State Trajectory", "Backprojection",
+    ):
+        assert name in summary
+    assert "8 samples" in summary
+    assert "DO7" in summary and "GD2_CART" in summary and "M21" in summary
+    assert "Questions suggested by your metadata" in summary
 
     action = app.analysis_navigation_action(
         {"current_step": "analysis", "analysis": {"view": "behavioral_state"}},
@@ -952,6 +983,152 @@ def test_hmm_all_movement_choice_updates_both_feature_lists():
         "net_displacement", "straightness",
     ]
     assert "mean_dead_dye" not in str(values)
+
+
+def _tcell_hmm_context():
+    prefix = "analysis.state_classification.T-cells."
+    return {
+        "current_step": "analysis",
+        "active_cell_type": "T-cells",
+        "analysis": {
+            "view": "behavioral_state",
+            "selected_cell_type": "T-cells",
+        },
+        "ui_state": {"controls": [
+            {
+                "id": prefix + "timepoint_features",
+                "visible": True, "enabled": True,
+                "choices": ["speed", "elongation"],
+                "value": ["speed"],
+            },
+            {
+                "id": prefix + "window_features",
+                "visible": True, "enabled": True,
+                "choices": ["net_displacement", "straightness"],
+                "value": ["net_displacement"],
+            },
+            {
+                "id": prefix + "binary_feature_groups",
+                "visible": True, "enabled": True,
+                "choices": [
+                    "Organoid_contact", "Macrophages_contact", "dead",
+                ],
+                "value": [],
+            },
+            {
+                "id": prefix + "n_states",
+                "visible": True, "enabled": True, "value": 6,
+            },
+        ]},
+    }
+
+
+def test_hmm_guidance_uses_live_selected_cell_type():
+    import app
+
+    context = _tcell_hmm_context()
+    setup = app.hmm_setup_guidance(
+        context,
+        [{"role": "user", "content": (
+            "I want to do behavioral analysis, can you take me through the steps?"
+        )}],
+    )
+    assert "T-cells" in setup
+    assert "currently have" in setup
+    assert "rename" in setup.lower() and "merge" in setup.lower()
+
+    groups = app.hmm_binary_group_guidance(
+        context,
+        [{"role": "user", "content": (
+            "Would it be worth adding macrophage contact?"
+        )}],
+    )
+    assert "T-cells" in groups
+    assert "a cell from T-cells is directly touching Macrophages".lower() in groups.lower()
+    assert "not a different population" in groups
+
+
+def test_hmm_binary_group_edit_targets_selected_cell_control():
+    import app
+
+    context = _tcell_hmm_context()
+    result = app.hmm_binary_group_action(
+        context,
+        [{"role": "user", "content": "Add organoid contact and also add dead"}],
+    )
+    assert "T-cells" in result["text"]
+    assert result["calls"] == [{
+        "name": "set_ui_value",
+        "arguments": {
+            "control_id": (
+                "analysis.state_classification.T-cells.binary_feature_groups"
+            ),
+            "value": ["Organoid_contact", "dead"],
+        },
+    }]
+
+
+def test_hmm_states_can_be_merged_by_reusing_names():
+    import app
+
+    response = app.hmm_state_merge_guidance(
+        _tcell_hmm_context(),
+        [{"role": "user", "content": (
+            "If I have 6 states, can I select which ones to keep?"
+        )}],
+    )
+    assert "T-cells" in response
+    assert "same name" in response
+    assert "merge" in response
+    assert "Rename Primary Dynamic State Clusters" in response
+    assert "outside BEHAV3D" not in response
+
+
+def test_chat_transcript_shows_waiting_block_and_tracks_role_colors():
+    assert streaming_transcript_block(True, "") == (
+        "**BEHAV3D Assistant**\n\n*Preparing a response...*"
+    )
+    assert streaming_transcript_block(False, None) is None
+    role = transcript_block_role("You")
+    assert role == "user"
+    assert transcript_block_role("My question", role) == "user"
+    assert transcript_block_role("BEHAV3D Assistant", role) == "assistant"
+
+
+def test_metadata_absence_values_are_csv_safe():
+    import app
+
+    assert normalize_metadata_line_value(None) == "not_added"
+    assert normalize_metadata_line_value("None") == "not_added"
+    assert normalize_metadata_line_value("(not_added)") == "not_added"
+    assert normalize_metadata_line_value("M21") == "M21"
+    controls = [{
+        "id": "metadata.samples.0.cell_types.Macrophages.line",
+        "label": "Sample 1, Macrophages: line",
+        "value": "",
+        "visible": True,
+        "enabled": True,
+    }]
+    action = build_actions([{
+        "name": "set_ui_value",
+        "arguments": {
+            "control_id": "metadata.samples.0.cell_types.Macrophages.line",
+            "value": None,
+        },
+    }], [], {}, controls=controls)[0]
+    assert action.ok
+    assert action.data["value"] == "not_added"
+    result = app.metadata_absence_action(
+        {
+            "current_step": "data_preparation",
+            "ui_state": {"controls": controls},
+        },
+        [{"role": "user", "content": (
+            "Macrophages were not added in Sample 1; set that line."
+        )}],
+    )
+    assert "not added" in result["text"]
+    assert result["calls"][0]["arguments"]["value"] == "not_added"
 
 
 def test_equal_track_filter_review_explains_valid_fixed_length_workflow():
@@ -1900,6 +2077,10 @@ def test_prompt_encodes_pi_feedback_scenarios():
     assert "setup_ready true" in sp
     assert "enumerate all movement choices" in sp
     assert "currently selected speed and net displacement" in sp
+    assert "read analysis.selected_cell_type" in sp
+    assert "assigning the same name to multiple primary clusters merges them" in sp
+    assert "Death Dynamics, Interaction Analysis, Invasiveness Analysis" in sp
+    assert "line to the literal CSV-safe value 'not_added'" in sp
 
 
 class _FakeSpin:
@@ -2180,7 +2361,7 @@ def test_metadata_validation_matches_required_well_and_population_lines():
         "cell_types": {
             "organoid": {"line": "DO7", "condition": ""},
             "T-cells": {"line": "", "condition": ""},
-            "Macrophages": {"line": "None", "condition": ""},
+            "Macrophages": {"line": "not_added", "condition": ""},
         },
     }]
     issues = validate_metadata_records(records)
@@ -2908,7 +3089,7 @@ def test_feedback_guidance_fixtures():
 
     fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
     cases = json.loads(fixture.read_text(encoding="utf-8"))
-    assert KNOWLEDGE_VERSION == "2026.07.24.24"
+    assert KNOWLEDGE_VERSION == "2026.07.27.25"
     for case in cases:
         cards = select_guidance_cards(
             {"current_step": case["step"]}, case["user"], case.get("intent"))


### PR DESCRIPTION
## Summary

Addresses the July 24 researcher feedback and the follow-up review covering Feature Extraction, Active Killing, HMM setup, metadata handling, analysis guidance, and chat presentation.

### Configuration safety and form actions

- Preserve mandatory feature groups and prevent recommendations that remove T-cell intensity when a dead-dye channel is configured.
- Expose required and editable choices in the live control contract and reject actions that remove required values.
- Allow Active Killing mode and threshold controls to be proposed together, apply complete accepted setups in one action batch, and report readiness from live values.
- Correct multi-target Active Killing guidance: selected targets are analyzed independently and in a combined analysis.
- Normalize absent configured metadata populations to the supported `not_added` sentinel in both deterministic and model-generated actions.

### HMM and analysis guidance

- Enumerate every movement feature available in the live HMM controls and update both timepoint and window feature lists when all movement features are requested.
- Ground HMM explanations and edits in the currently selected cell type so T-cell workflows are not described as macrophage workflows.
- Explain binary contact features from the selected-cell perspective and apply requested feature additions to the selected cell type.
- Correct six-state guidance: states can be renamed and merged in Step 2, and assigning the same name merges clusters.
- List all available General Analysis routes and use live metadata to suggest relevant research questions and pipelines.

### Chat experience and reliability

- Add a visible in-transcript waiting state while a response is being prepared.
- Give researcher and assistant messages distinct backgrounds, while keeping action/status output associated with the assistant.
- Centralize deterministic turn routing so feedback-critical answers and actions are testable without relying on probabilistic model wording.
- Expand guidance, transcript fixtures, unit tests, and deployed-API smoke scenarios for the new behavior.

## Root cause

The assistant had incomplete visibility into some disabled-but-dependent controls and mandatory choices, and several workflows relied on model prose rather than deterministic interpretation of the live form state. Guidance also contained stale assumptions about Active Killing targets, HMM state merging, metadata absence values, and the active HMM cell type.

## Impact

Researchers now receive advice based on the actual selected cell type, metadata, and live controls. The assistant avoids unsupported edits, applies accepted multi-field changes together, describes every available analysis route, correctly supports HMM state merging, and uses the metadata values expected by the application.

## Validation

- `101/101` local assistant tests passed.
- `55/55` conversation scenarios passed against the deployed Modal API.
- Targeted deployed checks passed for selected-cell HMM guidance, binary feature actions, state merging, complete analysis-route guidance, and `not_added` metadata handling.
- Offscreen Qt rendering confirmed the waiting state and distinct user/assistant transcript styling.
- Deployed knowledge version: `2026.07.27.25`.
- `git diff --check` passed.
