### PR TITLE
Ground assistant routing and experiment guidance

### DIFF
--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -232,7 +232,14 @@ The order in `POST /chat` is intentional:
 
 Within the deterministic and preflight chains, the first non-`None` handler
 wins. Place a new handler carefully and add a regression test for interactions
-with neighboring handlers.
+with neighboring handlers. A preflight handler must require explicit task intent,
+not just a topic word: mentioning an organoid line in an analysis question, for
+example, is not a metadata-building request. Put broad informational answers
+before setup clarifications when both could match.
+
+Keep deterministic response templates experiment-neutral. They may repeat names
+found in live metadata or an explicitly matched experiment reference, but must not
+embed line, strain, or population names copied from a previous feedback example.
 
 Use a deterministic handler when the answer or action can be derived from
 structured context. Use a guidance card for stable explanatory knowledge. Use

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -995,15 +995,23 @@ def metadata_channel_mapping_guidance(
     return (
         "The **Metadata Builder does not map raw channel indices to cell types**. "
         "Its sample forms hold image/acquisition details plus each processing "
-        "population's **Line** and **Condition**. Channel-input or channel-label "
-        "controls belong to the selected segmentation method, so I should not "
-        "describe Cellpose controls as metadata fields.\n\n"
+        "population's **Line** and **Condition**. Channel inputs are configured in "
+        "Segmentation.\n\n"
         "For swapped-channel replicates, a valid metadata structure is to name two "
         "generic processing slots for the physical immune channels (for example, "
         "**blue** and **green**) and record the true identity, such as CD4 or CD8, "
-        "in each slot's **Line** field for every sample. Should those two processing "
-        "slots follow the physical channels, with Line carrying the biological "
-        "identity per sample?"
+        "in each slot's **Line** field for every sample. A slot must stay tied to "
+        "the same physical raw channel across all samples processed by that model; "
+        "the channel choice is not independent per sample.\n\n"
+        "The model scope also differs by method: **APOC** trains one binary model "
+        "per processing population and exposes channel inputs for each model; the "
+        "CPU **Pixel Classifier** also trains one classifier per population; "
+        "**ConvPaint** trains one shared multiclass model with one shared channel "
+        "set; and **Cellpose-SAM** exposes channel inputs per population. If the raw "
+        "channel order itself changes between samples, normalize the order first or "
+        "process those samples as separate model groups. Should the generic slots "
+        "follow fixed physical channels, with Line carrying the biological identity "
+        "per sample?"
     )
 
 
@@ -1231,8 +1239,12 @@ def apoc_feature_preset_action(
         "I am configuring the **Segmentation > APOC > Tune Features** controls, "
         f"not Feature Extraction or instance post-processing: {details}. Each preset "
         "selects Gaussian, DoG, LoG, and SoG at those scales and includes original "
-        "intensity. Retrain each classifier and inspect its probability-map preview "
-        "after applying the changes."
+        "intensity. Use this as a first pass, retrain, inspect the probability-map "
+        "preview, and open **Show classifier statistics**. In that table, greener "
+        "importance cells are more informative and redder cells are less informative. "
+        "Remove only consistently low-importance features, then retrain and preview "
+        "again; a broader custom scale set is useful when the first preset misses an "
+        "important object scale."
     )
     if not calls:
         text += " Those presets and Tune Features panels are already set, so no edit is needed."
@@ -1324,7 +1336,13 @@ def apoc_feature_grid_guidance(
         "rows at sigma **1, 2, 5**; Medium uses **1, 2, 5, 15**; Large uses "
         "**1, 2, 5, 10, 25**. All three presets include original intensity, which "
         "adds raw pixel values as a classifier feature. "
-        f"{availability}{scale_text}{recommendation} Changes here require retraining. "
+        f"{availability}{scale_text}{recommendation} Treat the preset as the first "
+        "pass rather than the final answer. If it misses relevant object scales, try "
+        "a broader candidate set, retrain, and inspect **Show classifier statistics**. "
+        "The importance table runs from greener, more informative cells toward redder, "
+        "less informative cells. Remove only features that remain uninformative, then "
+        "retrain and compare the probability-map preview again. Changes here require "
+        "retraining. "
         "These controls are separate from Minimum size, EDT, Mask threshold, Seed "
         "threshold, and the later Feature Extraction tab."
     )
@@ -1414,10 +1432,30 @@ def feature_threshold_guidance(
     if context.get("current_step") != "feature_extraction":
         return None
     latest = " ".join(_latest_user_message(messages).lower().split())
-    if "contact" not in latest or not any(term in latest for term in (
+    contact_request = "contact" in latest and any(term in latest for term in (
         "distance", "threshold", "set", "correct", "mean", "1.01", "touch",
-    )):
+    ))
+    death_request = any(term in latest for term in ("dead", "death")) and any(
+        term in latest for term in (
+            "threshold", "percentage", "percent", "set", "correct", "preview",
+            "first time", "calibrat",
+        )
+    )
+    if not contact_request and not death_request:
         return None
+
+    death_text = (
+        "Use **Preview Dead Threshold in Viewer** before relying on result PDFs or "
+        "choosing a number. Select the sample and population, open the preview, and "
+        "adjust the threshold above it: the overlay updates live; **green is below "
+        "the threshold (alive)** and **red is above it (dead)**; hovering an object shows "
+        "its measured dead-mask percentage. Calibrate against cells or organoids you "
+        "can confidently identify as alive or dead. The live context does not justify "
+        "a universal numeric range. Re-run Feature Extraction after choosing the "
+        "threshold."
+    )
+    if not contact_request:
+        return death_text
 
     controls = (context.get("ui_state", {}) or {}).get("controls", []) or []
     active = str(context.get("active_cell_type") or "")
@@ -1448,22 +1486,14 @@ def feature_threshold_guidance(
             "one-pixel XY gap, so it is close-proximity contact rather than strict "
             "mask touching."
         )
-    death_text = ""
-    if "dead" in latest or "death" in latest:
-        death_text = (
-            " For the dead-mask percentage, use the Feature Extraction preview: "
-            "green is below the threshold (alive), red is above it (dead), and hover "
-            "shows the measured percentage. Calibrate from cells you can confidently "
-            "classify as alive or dead; the live context does not justify a universal "
-            "numeric range."
-        )
+    appended_death = f" {death_text}" if death_request else ""
     return (
         "**Contact distance 0 µm means strict mask touching.** Any positive value "
         "permits that much physical separation between masks and therefore changes "
         "the biological definition from touching to proximity."
         + current_text + scale_text
         + " Re-run Feature Extraction after changing the contact distance."
-        + death_text
+        + appended_death
     )
 
 
@@ -1492,6 +1522,44 @@ def missing_log_error_question(context: dict, messages: list[dict]) -> str | Non
     )
 
 
+def result_opening_correction(
+    context: dict, messages: list[dict],
+) -> str | None:
+    """Stop repeated claims after the researcher reports that nothing opened."""
+    latest = " ".join(_latest_user_message(messages).lower().split())
+    correction = any(phrase in latest for phrase in (
+        "you cannot open", "you can not open", "you can't open",
+        "nothing opened", "it did not open", "it didn't open",
+        "not opening", "cannot open it", "can't open it",
+    ))
+    history = " ".join(
+        str(message.get("content") or "").lower()
+        for message in messages[:-1]
+        if message.get("role") == "assistant"
+    )
+    if not correction or not any(term in history for term in ("open", "opening")):
+        return None
+    preview = ""
+    prior_conversation = " ".join(
+        str(message.get("content") or "").lower()
+        for message in messages[:-1]
+    )
+    if context.get("current_step") == "feature_extraction" and any(
+        term in prior_conversation for term in ("dead", "death", "threshold")
+    ):
+        preview = (
+            " For death-threshold calibration, use **Preview Dead Threshold in "
+            "Viewer** in Feature Extraction; it provides the green alive/red dead "
+            "overlay and the measured percentage on hover."
+        )
+    return (
+        "**No result was opened.** A file being listed as viewable does not mean it "
+        "has opened. Open the exact item from the **Results** panel, or name the exact "
+        "result you want opened so it can be matched to a viewable result."
+        + preview
+    )
+
+
 def historical_reference_guidance(
     context: dict, messages: list[dict],
 ) -> dict | None:
@@ -1503,9 +1571,49 @@ def historical_reference_guidance(
         "historical setting", "reference profile", "reference configuration",
         "similar experiment", "similar dataset", "values used before",
         "what did you use", "used previously", "prior experiment",
-    ))
+    )) or (
+        any(term in latest for term in ("previous", "past", "prior", "historical"))
+        and "experiment" in latest
+    )
     if not historical_request:
         return None
+
+    if any(term in latest for term in (
+        "microglia", "macrophage", "exp91", "dmg", "dipg", "gd2",
+    )):
+        return {
+            "text": (
+                "**Historical example: Exp91 DMG organoid, macrophage/microglia, "
+                "and GD2 CAR-T co-culture.** The metadata CSV records eight wells, "
+                "1.77 µm isotropic sampling, 120-second frames, TCZYX order, and "
+                "five channels: brightfield 0, T cell 1, macrophage/microglia 2, "
+                "dead-cell dye 3, and organoid 4. The three organoid lines were kept "
+                "as one processing population because only one line occurred per "
+                "movie; line identity was retained for analysis. Macrophage/microglia "
+                "conditions were no added cells, M21, and M23. The historical CSV "
+                "uses the legacy value **None_None** for no added macrophages; track "
+                "paths in those wells contain segmentation noise and are not evidence "
+                "that macrophages were present.\n\n"
+                "The saved YAML uses APOC Probability Map + Watershed: organoid "
+                "channels 3 and 4 with mask/seed thresholds 0.5/0.8 and minimum size "
+                "1000 voxels; macrophage channel 2 and T-cell channel 1 with "
+                "0.5/0.6 and minimum sizes 100 and 30 voxels. Organoids and "
+                "macrophages used Propagation; T cells used btrack with maximum "
+                "search radius 150, optimizer distance 100, time threshold 5 frames, "
+                "and global optimization enabled. Active Killing was configured as "
+                "an absolute increase of 30 dead-mask pixels within 5 frames after "
+                "at least one contact frame.\n\n"
+                "Only T cells had behavioral classification: four HMM states and "
+                "50-timepoint trajectory windows. One source conflict must remain "
+                "visible: the saved YAML has HMM Start offset **0**, while the README "
+                "describes **1**. The design is also incomplete and unreplicated: "
+                "DIPG002ns has no M21 well, and each included combination has n=1, "
+                "so comparisons are descriptive or exploratory. These are sourced "
+                "historical values, not defaults, and I am not proposing form edits "
+                "from them."
+            ),
+            "calls": [],
+        }
 
     if (
         any(term in latest for term in ("calcium", "reporter", "islet"))
@@ -2893,7 +3001,9 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "You are the BEHAV3D Assistant for researchers analysing 3D fluorescence imaging. "
         "Answer the user's actual question first, then add only context that helps them decide "
         "or act. Use concise researcher-facing labels and never expose control IDs, variable "
-        "names, dotted configuration keys, JSON, or tool names in normal prose.\n\n"
+        "names, dotted configuration keys, JSON, or tool names in normal prose. Never narrate "
+        "internal rules, policies, prompting, capability checks, or reasoning with phrases such "
+        "as 'I should not' or 'my rules say'; give the resulting researcher-facing answer directly.\n\n"
         "TRUST AND SCOPE\n"
         "- The LIVE CONTEXT is authoritative. Read all loaded metadata records and current control "
         "values before asking for information. Never ask for a value already present.\n"
@@ -3001,6 +3111,12 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "- Never tell the user to click a field that you can edit with set_ui_value.\n"
         "- Do not claim an action succeeded in prose. State the intended change briefly; the client "
         "reports whether it was applied.\n"
+        "- Opening a result requires an open_result call with the exact id of a viewable item from "
+        "LIVE CONTEXT in the same response. Never say 'I will open', 'let me open', 'I am opening', "
+        "or 'try opening' without that call. A result merely listed as viewable has not been opened. "
+        "If no single exact result can be identified, say that it was not opened and direct the "
+        "researcher to the Results panel or the relevant built-in preview. Even when the call is "
+        "present, describe the intended opening rather than claiming it succeeded.\n"
         "- For EDT advice, use recommend_edt so the conversion comes from metadata. Use a 10 um cell "
         "diameter by default. For an organoid, first ask how many cell widths span its diameter. Treat "
         "the returned values as preview starting points, not ground truth.\n"
@@ -3351,6 +3467,7 @@ def deterministic_turn_response(
 
     preflight_question = (
         metadata_channel_mapping_guidance(context, messages)
+        or result_opening_correction(context, messages)
         or analysis_choice_summary(context, messages)
         or organoid_processing_question(context, messages)
         or metadata_identifier_confirmation_question(context, messages)

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -158,6 +158,38 @@ def _latest_user_message(messages: list[dict]) -> str:
     ), "")
 
 
+def _normalized_user_message(messages: list[dict]) -> str:
+    return " ".join(_latest_user_message(messages).lower().split())
+
+
+def _asks_general_analysis_question(messages: list[dict]) -> bool:
+    """Recognize an analysis overview without stealing requests for one view."""
+    latest = _normalized_user_message(messages)
+    targeted = any(phrase in latest for phrase in (
+        "death dynamics", "interaction analysis", "invasiveness analysis",
+        "active killing", "behavioral state", "behavioural state",
+        "state trajectory", "contact-based grouping", "contact based grouping",
+        "state-shift", "state shift", "backprojection",
+    ))
+    if targeted:
+        return False
+    return bool(
+        re.search(
+            r"\b(?:what|which|choose|pick)\b.{0,36}\banalys(?:is|es)\b",
+            latest,
+        )
+        or re.search(
+            r"\banalys(?:is|es)\b.{0,48}"
+            r"\b(?:possible|available|options?|recommend|suitable|useful|nice)\b",
+            latest,
+        )
+        or any(phrase in latest for phrase in (
+            "help me choose an analysis", "help me choose analysis",
+            "help me pick an analysis", "help me pick what analysis",
+        ))
+    )
+
+
 def organoid_processing_question(context: dict, messages: list[dict]) -> str | None:
     """Resolve whether organoid lines are processing types before any bulk fill."""
     metadata = context.get("metadata", {}) or {}
@@ -166,6 +198,8 @@ def organoid_processing_question(context: dict, messages: list[dict]) -> str | N
         return None
 
     latest = _latest_user_message(messages)
+    if _asks_general_analysis_question(messages):
+        return None
     user_history = " ".join(
         str(message.get("content") or "").lower()
         for message in messages
@@ -183,11 +217,17 @@ def organoid_processing_question(context: dict, messages: list[dict]) -> str | N
         return None
 
     latest_normalized = " ".join(latest.lower().split())
+    explicit_metadata_request = (
+        "metadata" in latest_normalized
+        and any(phrase in latest_normalized for phrase in (
+            "build", "create", "set up", "setup", "fill", "prepare",
+            "help me", "walk through",
+        ))
+    )
     setup_turn = (
         "organoid" in latest_normalized
-        and any(phrase in latest_normalized for phrase in (
-            "metadata", "set up", "setup", "line", "co-culture", "coculture",
-        ))
+        and "line" in latest_normalized
+        and explicit_metadata_request
     )
     previous_assistant = next((
         str(message.get("content") or "").lower()
@@ -219,20 +259,29 @@ def metadata_identifier_confirmation_question(
     builder = context.get("metadata_builder", {}) or {}
     if not builder.get("sample_forms_created"):
         return None
-    latest = " ".join(_latest_user_message(messages).lower().split())
-    if not (
-        any(phrase in latest for phrase in ("no well", "without well", "no wells"))
-        and any(token in latest for token in (" line", "m21", "m23", "t-cell", "t cell"))
-    ):
+    latest = _normalized_user_message(messages)
+    missing_well = any(phrase in latest for phrase in (
+        "no well", "without well", "no wells", "not using a well",
+        "not using wells", "don't have well", "do not have well",
+    ))
+    missing_line = any(phrase in latest for phrase in (
+        "no line", "without line", "no lines", "line is missing",
+        "lines are missing", "haven't specified the line",
+        "haven't specified lines", "have not specified the line",
+        "have not specified lines", "line not specified", "lines not specified",
+    ))
+    if not (missing_well or missing_line):
         return None
     return (
         "Well and the line for every configured cell or organoid type are mandatory; "
-        "condition is optional. Since there are no physical well identifiers, I can "
-        "propose **1** for every sample. Before I fill the line fields, please confirm: "
-        "should each line you gave apply to all relevant samples, should M21/M23 be "
-        "inferred only where those suffixes appear in a filename, and should a sample "
-        "without a macrophage suffix be described as **not added** and use the line "
-        "value **not_added**?"
+        "condition is optional. If the experiment has no physical well identifiers, "
+        "you can use one consistent placeholder such as **1**, after confirming that "
+        "choice. Enter the actual line for every population present in each sample; "
+        "for a configured population that was **not added** to a sample, use "
+        "**not_added**. I will not "
+        "infer line values from filenames or apply one line to multiple samples unless "
+        "you confirm that mapping. Tell me which identifiers are missing, or ask me to "
+        "check the current metadata form."
     )
 
 
@@ -415,31 +464,29 @@ def _metadata_analysis_profile(context: dict) -> dict:
 
 def analysis_choice_summary(context: dict, messages: list[dict]) -> str | None:
     """List every analysis route and connect it to the live experiment design."""
-    latest = " ".join(_latest_user_message(messages).lower().split())
+    latest = _normalized_user_message(messages)
     intent = str((context.get("assistant_session") or {}).get("intent") or "")
     targeted_single_cell = any(phrase in latest for phrase in (
         "classify behavioral tracks", "classify behavioural tracks",
         "state trajectory", "track classification",
     ))
-    asks_general = (
-        bool(re.search(
-            r"\b(?:what|which|choose|pick)\b.{0,28}\banalys(?:is|es)\b",
-            latest,
-        ))
-        or "analysis would be nice" in latest
-        or "analysis is possible" in latest
-        or "help me choose an analysis" in latest
-    )
+    asks_general = _asks_general_analysis_question(messages)
     if (intent != "choose_analysis" and not asks_general) or targeted_single_cell:
         return None
 
+    metadata = context.get("metadata", {}) or {}
+    has_live_metadata = bool(
+        metadata.get("loaded")
+        or metadata.get("record_source") in {
+            "metadata_builder_draft", "loaded_metadata_copy",
+        }
+    )
     profile = _metadata_analysis_profile(context)
     populations = profile["populations"]
     all_populations = (
         populations["organoid"] + populations["immune"] + populations["other"]
     )
-    snapshot = ""
-    if profile["n_samples"] or all_populations:
+    if has_live_metadata and (profile["n_samples"] or all_populations):
         sample_text = (
             f"**{profile['n_samples']} samples**"
             if profile["n_samples"] else "the loaded samples"
@@ -453,30 +500,76 @@ def analysis_choice_summary(context: dict, messages: list[dict]) -> str | None:
             + (f" Recorded lines/conditions include **{lines}**." if lines else "")
             + "\n\n"
         )
+    elif has_live_metadata:
+        snapshot = (
+            "Metadata is loaded, but I cannot identify configured populations from "
+            "the current records, so the overview below is not yet prioritized.\n\n"
+        )
+    else:
+        described = []
+        for terms, label in (
+            (("t cell", "t-cell", "tcell"), "T cells"),
+            (("macrophage",), "macrophages"),
+            (("organoid",), "organoids"),
+        ):
+            if any(term in latest for term in terms):
+                described.append(label)
+        description = (
+            f" You described **{', '.join(described)}**, so I can still suggest "
+            "relevant routes conditionally."
+            if described else ""
+        )
+        snapshot = (
+            "No metadata is loaded, so I cannot yet confirm sample counts, configured "
+            f"populations, lines, or death-signal availability.{description}\n\n"
+        )
+
+    described_organoid = "organoid" in latest
+    described_immune_labels = []
+    for terms, label in (
+        (("t cell", "t-cell", "tcell"), "T cells"),
+        (("macrophage",), "macrophages"),
+        (("immune",), "immune cells"),
+    ):
+        if any(term in latest for term in terms) and label not in described_immune_labels:
+            described_immune_labels.append(label)
+    described_immune = bool(described_immune_labels)
+    has_organoid = bool(populations["organoid"]) or described_organoid
+    has_immune = bool(populations["immune"]) or described_immune
+    immune_labels = populations["immune"] or described_immune_labels
+    immune_subject = " or ".join(immune_labels[:4]) or "immune cells"
 
     questions = []
-    if populations["organoid"]:
+    if has_organoid:
         questions.append(
-            "Do target or organoid lines differ in death timing? Start with "
-            "**Death Dynamics**."
+            "Do organoid lines differ in survival or death timing? Use **Death "
+            "Dynamics** if a death signal is available."
         )
-    if populations["organoid"] and populations["immune"]:
+    if has_organoid and has_immune:
         questions.extend([
-            "Do immune contacts differ by target condition, and are they associated "
-            "with death? Use **Interaction Analysis**.",
-            "Do immune cells engage or enter targets to different degrees? Use "
-            "**Invasiveness Analysis**, if invasiveness features were extracted.",
+            f"Do {immune_subject} contact different organoid lines differently, "
+            "and is contact associated with death? Use **Interaction Analysis**.",
+            "How much of each immune cell surface engages an organoid? Use "
+            "**Invasiveness Analysis** after extracting invasiveness features.",
+            "Do sustained-contact tracks occupy different trajectory clusters, or do "
+            "cell states change after contact? Use **Contact-Based Grouping** and "
+            "**Contact State-Shift Analysis** under State Trajectory.",
         ])
-    if populations["immune"]:
+    if has_immune:
         questions.append(
             "Do immune populations occupy different dynamic states or complete "
             "different behavioral programs? Use **Behavioral State**, then "
             "**State Trajectory**."
         )
-    if populations["organoid"] and populations["immune"] and profile["dead_signal"]:
+    if has_organoid and has_immune:
+        availability = (
+            "The loaded metadata includes a death signal."
+            if profile["dead_signal"] else
+            "This requires a configured death signal and the relevant extracted features."
+        )
         questions.append(
             "Which individual immune cells show contact-associated target killing? "
-            "Use **Active Killing** after feature extraction."
+            f"Use **Active Killing** after feature extraction. {availability}"
         )
     if not questions:
         questions.append(
@@ -484,22 +577,38 @@ def analysis_choice_summary(context: dict, messages: list[dict]) -> str | None:
             "prerequisites before running it."
         )
     question_text = "\n".join(f"- {question}" for question in questions)
+    question_heading = (
+        "Questions suggested by your metadata"
+        if has_live_metadata else "Questions suggested from your description"
+    )
     return (
         f"{snapshot}"
-        "BEHAV3D offers these analysis routes:\n"
-        "1. **Death Dynamics** - target survival, death timing, and disappearance.\n"
-        "2. **Interaction Analysis** - target-centered contact patterns and their "
-        "relationship to death.\n"
-        "3. **Invasiveness Analysis** - immune-cell engagement with targets over time "
-        "and per movie.\n"
-        "4. **Active Killing** - contact-associated target death attributed to "
-        "individual immune cells; configured under Feature Extraction.\n"
-        "5. **Behavioral State** - an HMM state for each selected-cell timepoint.\n"
-        "6. **State Trajectory** - clusters whole state sequences into behavioral "
-        "programs.\n"
-        "7. **Backprojection** - overlays state, trajectory, or killing results on the "
-        "images for visual validation.\n\n"
-        "**Questions suggested by your metadata**\n"
+        "| Analysis | What it answers |\n"
+        "|---|---|\n"
+        "| **Death Dynamics** | How target survival and death timing differ across "
+        "samples or conditions. |\n"
+        "| **Interaction Analysis** | How target-contact patterns differ and whether "
+        "they are associated with target death. |\n"
+        "| **Invasiveness Analysis** | How much of an immune cell's surface engages a "
+        "target over time and per movie. |\n"
+        "| **Active Killing** | Which individual immune cells have contact-associated "
+        "target-death events; configured during Feature Extraction. |\n"
+        "| **Behavioral State** | Which recurring state each selected cell occupies at "
+        "each timepoint. |\n"
+        "| **State Trajectory** | Which whole-track behavioral programs occur and how "
+        "their proportions differ by condition. |\n"
+        "| **Contact-Based Grouping** | Whether State Trajectory clusters differ "
+        "between tracks with and without a sustained contact bout. |\n"
+        "| **Contact State-Shift Analysis** | Whether behavioral-state composition "
+        "changes before versus after contact, compared with matched no-contact tracks. |\n"
+        "| **Backprojection** | Where state, trajectory, or killing labels occur in the "
+        "original images for visual validation. |\n\n"
+        "Interaction and Invasiveness are in the **Death Dynamics** analysis tab. "
+        "State Trajectory also provides diagnostics, track-proportion plots, condition "
+        "comparisons, exemplar tracks, and the two contact analyses above. Contact-Based "
+        "Grouping requires contact features and Categorical DTW classification; Contact "
+        "State-Shift additionally requires Behavioral State results.\n\n"
+        f"**{question_heading}**\n"
         f"{question_text}\n\n"
         "For an immune-cell behavior question, the usual sequence is **Behavioral "
         "State -> rename or merge states -> State Trajectory -> Backprojection**. "
@@ -2866,12 +2975,16 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "as multiple organoid types or together as one organoid type with line identity per sample. "
         "Recommend separate types when multiple organoid identities coexist in the same movie and must "
         "be processed separately; otherwise one processing type is normally appropriate. Do not emit "
-        "metadata actions until the researcher explicitly chooses.\n"
+        "metadata actions until the researcher explicitly chooses. Ask this only for an explicit metadata "
+        "creation/editing request; never override an informational or analysis question merely because it "
+        "mentions organoid lines.\n"
         "- Metadata Well and the line for every configured population in every sample are mandatory. "
         "Population condition is optional. If there are no physical well identifiers, propose one "
         "deterministic shared value such as '1' and ask for confirmation. Before filling population "
         "lines, establish whether each line is shared across all samples. Filename suffixes are only "
-        "proposed inferences. For a sample where a configured population is confirmed absent, set its "
+        "proposed inferences. Keep clarification wording experiment-neutral and never introduce example "
+        "line, strain, or population names that are not in the live context. For a sample where a configured "
+        "population is confirmed absent, set its "
         "line to the literal CSV-safe value 'not_added' and describe it to the researcher as 'not "
         "added'; never write None and never leave a mandatory line blank.\n"
         "- Use only controls matching the selected method and exact cell type. Do not apply a change to "
@@ -3028,11 +3141,14 @@ def build_system_prompt(context: dict, retrieved: list[dict], tools: list[dict])
         "manually edited outside BEHAV3D.\n"
         "- For State Trajectory, Trajectory size cannot exceed the Filtering trim. Average linkage is the "
         "default, Complete is a reasonable comparison, and Single performs poorly. Original BEHAV3D mode is "
-        "deprecated. Be transparent that contact-based comparison plots and exemplar-track exports are known "
-        "to be unreliable in the current implementation.\n"
+        "deprecated. Categorical DTW supports Contact-Based Grouping for sustained-contact versus no-contact "
+        "tracks and Contact State-Shift Analysis for before/after-contact state composition; the latter also "
+        "requires Behavioral State results. Do not claim these current contact analyses are unavailable or "
+        "known to produce empty output.\n"
         "- A general analysis-choice request must enumerate all relevant routes: Death Dynamics, Interaction "
-        "Analysis, Invasiveness Analysis, Active Killing, Behavioral State, State Trajectory, and "
-        "Backprojection. Then use the loaded metadata populations, lines/conditions, and dead-signal "
+        "Analysis, Invasiveness Analysis, Active Killing, Behavioral State, State Trajectory, Contact-Based "
+        "Grouping, Contact State-Shift Analysis, and Backprojection. Then use the loaded metadata "
+        "populations, lines/conditions, and dead-signal "
         "availability to propose concrete biological questions and a sensible sequence, while distinguishing "
         "configured prerequisites from results that actually exist. Do not navigate for this overview. When the "
         "user names a specific view and asks to open it, use open_analysis_view. Never repeatedly navigate "
@@ -3235,10 +3351,10 @@ def deterministic_turn_response(
 
     preflight_question = (
         metadata_channel_mapping_guidance(context, messages)
+        or analysis_choice_summary(context, messages)
         or organoid_processing_question(context, messages)
         or metadata_identifier_confirmation_question(context, messages)
         or metadata_completion_summary(context, messages)
-        or analysis_choice_summary(context, messages)
         or safety_profile_summary(context, messages)
         or active_killing_readiness_summary(context, messages)
         or feature_group_requirement_guidance(context, messages)

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-KNOWLEDGE_VERSION = "2026.07.27.25"
+KNOWLEDGE_VERSION = "2026.07.27.27"
 
 
 GUIDANCE_CARDS = {
@@ -29,7 +29,10 @@ GUIDANCE_CARDS = {
         "line identity recorded per sample. Well and each configured population's line are mandatory; "
         "condition is optional. When no physical wells exist, propose one shared identifier such as "
         "'1'. When a configured population is confirmed absent, describe it as not added and use "
-        "the literal CSV-safe line value 'not_added'; never use None."
+        "the literal CSV-safe line value 'not_added'; never use None. Metadata clarification "
+        "prompts must stay experiment-neutral: do not introduce example strain, line, or population "
+        "names that were not read from the live context, and do not interrupt an informational "
+        "analysis question with a metadata-building clarification."
     ),
     "experiment_design": (
         "Use the loaded experiment reference only for the current dataset. Preserve explicit "
@@ -233,7 +236,8 @@ GUIDANCE_CARDS = {
     "analysis": (
         "First identify the research question and the active analysis view. A general analysis overview "
         "must include Death Dynamics, Interaction Analysis, Invasiveness Analysis, Active Killing, "
-        "Behavioral State, State Trajectory, and Backprojection, then use the live metadata to suggest "
+        "Behavioral State, State Trajectory, Contact-Based Grouping, Contact State-Shift Analysis, "
+        "and Backprojection, then use the live metadata to suggest "
         "dataset-specific questions and a sensible sequence. It must not repeatedly navigate to the "
         "Analysis tab. Open a named "
         "view directly when the researcher asks. Behavioral State assigns "
@@ -278,10 +282,13 @@ GUIDANCE_CARDS = {
         "set in Filtering. Average linkage is the default; Complete is a reasonable comparison, while "
         "Single linkage performs poorly. If Behavioral State should remain unfiltered, trim or divide "
         "tracks here instead. Original BEHAV3D feature-based mode is deprecated and requires equal "
-        "track lengths. The UMAP may look poor even when agglomerative clusters are sensible. The "
-        "contact-based comparison plots are currently known to produce empty output, and exemplar "
-        "track PDF/MP4 generation is also known to error; state these limitations rather than implying "
-        "those outputs are reliable."
+        "track lengths. The UMAP may look poor even when agglomerative clusters are sensible. "
+        "Categorical DTW supports Contact-Based Grouping, which compares trajectory clusters for "
+        "tracks with and without a sufficiently long contact bout. It also supports Contact State-Shift "
+        "Analysis, which compares behavioral-state composition before and after contact against "
+        "timing-matched no-contact tracks and therefore additionally requires Behavioral State results. "
+        "Do not repeat the obsolete claim that these current contact analyses inherently produce empty "
+        "output."
     ),
 }
 

--- a/chatbot/guidance.py
+++ b/chatbot/guidance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-KNOWLEDGE_VERSION = "2026.07.27.27"
+KNOWLEDGE_VERSION = "2026.07.27.28"
 
 
 GUIDANCE_CARDS = {
@@ -71,7 +71,13 @@ GUIDANCE_CARDS = {
         "Cellpose-SAM import; Reporter Propagation for near-static intermittent detections; historical "
         "100-voxel noise and 10% overlap values; a five-state HMM on one reporter-intensity fold-change "
         "feature with smoothing 1 and a full 32-frame trajectory. Use it to explain intensity-driven "
-        "behavior, not as a motility template. For any spatial btrack value, calculate or measure "
+        "behavior, not as a motility template. Exp91 microglia example: eight DMG-organoid/GD2-CAR-T "
+        "wells with optional M21 or M23 macrophage/microglia, 1.77 um isotropic sampling and 120 s "
+        "frames; APOC Probability Map + Watershed; organoid and macrophage Propagation; T-cell btrack; "
+        "absolute Active Killing at a 30-dead-mask-pixel increase over 5 frames. The matrix is incomplete "
+        "and every included combination has n=1. Its historical CSV uses None_None for absent macrophages, "
+        "and the YAML Start offset 0 conflicts with README Start offset 1. Preserve both source values. "
+        "For any spatial btrack value, calculate or measure "
         "per-frame displacement; for optimizer values, ask for the largest spatial and missing-frame "
         "gap; for segmentation thresholds, use the current resolution and preview."
     ),
@@ -119,7 +125,12 @@ GUIDANCE_CARDS = {
         "Medium structures uses 1, 2, 5, and 15; Large structures uses 1, 2, 5, 10, and 25. The "
         "original-intensity checkbox adds raw pixel intensity as a feature, so never claim APOC "
         "cannot learn from raw voxels. Tune Features never means Minimum size, EDT, Mask threshold, "
-        "Seed threshold, or Feature Extraction. A classifier is trained only when a classifier "
+        "Seed threshold, or Feature Extraction. Treat a preset as a first pass. If needed, train a "
+        "broader candidate set of scales, then use Show classifier statistics: greener importance "
+        "cells are more informative and redder cells are less informative. Remove only consistently "
+        "low-importance features, retrain, and compare the probability-map preview again. Do not infer "
+        "classifier quality from object size or sigma selection alone. A classifier is trained only "
+        "when a classifier "
         "file is actually found. APOC "
         "direct instance segmentation is only for sparse, non-touching objects where every "
         "connected region should remain one instance. Mask + EDT is preferred for similarly sized "
@@ -199,7 +210,9 @@ GUIDANCE_CARDS = {
         "to the XY pixel size permits a one-XY-pixel gap; it is not strict touching and is not a voxel "
         "diagonal. Any contact-distance "
         "change requires feature extraction to be run again, so plan it as a batch decision rather "
-        "than an interactive sweep. In the dead-threshold preview, green means alive and red means "
+        "than an interactive sweep. For a first-time death threshold, prioritize Preview Dead Threshold "
+        "in Viewer before result PDFs or a numeric suggestion: select a sample and population, open the "
+        "preview, then adjust the threshold while the overlay updates. Green means alive and red means "
         "dead; hovering shows the dead-mask percentage. If ambiguous, ask what looks wrong before "
         "recommending a threshold. Cell-type grouping creates a merged metadata type without "
         "requiring tracks to be recomputed."

--- a/chatbot/smoke_test.py
+++ b/chatbot/smoke_test.py
@@ -788,6 +788,58 @@ def _contact_and_dead_threshold_case() -> dict:
     }
 
 
+def _first_dead_threshold_preview_case() -> dict:
+    return {
+        "name": "dead_threshold_uses_viewer_preview_first",
+        "messages": [{
+            "role": "user",
+            "content": (
+                "In Feature Extraction, how should I set the correct dead-mask "
+                "percentage threshold for the first time?"
+            ),
+        }],
+        "context": _context(
+            "feature_extraction", [], active_cell_type="tcell",
+            results=[{
+                "id": "analysis/tcell/BEHAV3D_dead_dye_distribution.pdf",
+                "label": "Dead dye distribution",
+                "description": "Distribution used to tune the dead-dye threshold.",
+                "kind": "pdf",
+                "category": "filtering",
+                "cell_type": "tcell",
+                "viewable": True,
+            }],
+        ),
+        "check": _check_first_dead_threshold_preview,
+    }
+
+
+def _failed_result_opening_correction_case() -> dict:
+    return {
+        "name": "failed_result_opening_does_not_loop",
+        "messages": [
+            {
+                "role": "user",
+                "content": "How should I set the dead-mask percentage threshold?",
+            },
+            {
+                "role": "assistant",
+                "content": "The result is listed as viewable. Let me open it.",
+            },
+            {"role": "user", "content": "I think you cannot open it."},
+        ],
+        "context": _context(
+            "feature_extraction", [], active_cell_type="tcell",
+            results=[{
+                "id": "analysis/tcell/BEHAV3D_dead_dye_distribution.pdf",
+                "label": "Dead dye distribution",
+                "viewable": True,
+            }],
+        ),
+        "check": _check_failed_result_opening_correction,
+    }
+
+
 def _loaded_metadata_not_unsaved_case() -> dict:
     return {
         "name": "loaded_metadata_is_not_called_unsaved",
@@ -1598,6 +1650,38 @@ def _historical_calcium_example_case() -> dict:
     }
 
 
+def _historical_microglia_example_case() -> dict:
+    return {
+        "name": "historical_microglia_exp91_preserves_sources_and_caveats",
+        "messages": [{
+            "role": "user",
+            "content": (
+                "What design and settings were used in the previous microglia "
+                "Exp91 experiment?"
+            ),
+        }],
+        "context": _context(
+            "analysis", [], active_cell_type="tcell",
+            metadata={
+                "loaded": True,
+                "records": [{
+                    "sample_name": "CurrentMicroglia",
+                    "pixel_distance_xy": 0.8,
+                    "pixel_distance_z": 2.0,
+                    "time_interval": 3,
+                    "time_unit": "min",
+                }],
+                "cell_types": {
+                    "organoid": ["organoid"],
+                    "immune": ["microglia", "tcell"],
+                },
+                "validation": [],
+            },
+        ),
+        "check": _check_historical_microglia_example,
+    }
+
+
 def _experiment_reference_metadata_conflict_case() -> dict:
     reference = {
         "notes": [{
@@ -2207,14 +2291,17 @@ def _check_swapped_channel_metadata(result: dict) -> list[str]:
     errors = []
     for phrase in (
         "metadata builder does not map raw channel indices",
-        "line", "processing slots", "segmentation method",
+        "line", "processing slots", "segmentation",
+        "not independent per sample", "shared multiclass model",
     ):
         if phrase not in text:
             errors.append(f"missing swapped-channel boundary guidance: {phrase}")
     if any(phrase in text for phrase in (
-        "each sample form has a channel", "same for all", "per-sample dropdown",
+        "each sample form has a channel", "per-sample dropdown",
+        "choose different channel numbers for the same processing slot",
+        "i should not", "my rules say",
     )):
-        errors.append("invented metadata channel-mapping controls")
+        errors.append("invented per-sample channel mapping or exposed internal rules")
     if result["calls"]:
         errors.append("attempted edits before the slot workflow was confirmed")
     return errors
@@ -2260,6 +2347,7 @@ def _check_apoc_feature_grid(result: dict) -> list[str]:
         "feature scales in pixels", "gaussian blur", "difference of gaussians",
         "laplacian of gaussian", "sobel-of-gaussian",
         "not a structure tensor", "current live apoc controls",
+        "show classifier statistics", "greener", "redder",
     ):
         if phrase not in text:
             errors.append(f"missing APOC feature-grid detail: {phrase}")
@@ -2288,6 +2376,7 @@ def _check_apoc_tune_features_explanation(result: dict) -> list[str]:
         "laplacian of gaussian", "sobel-of-gaussian",
         "small structures", "medium", "large",
         "original intensity", "changes here require retraining",
+        "show classifier statistics", "greener", "redder",
     ):
         if phrase not in text:
             errors.append(f"missing Tune Features explanation: {phrase}")
@@ -2306,7 +2395,7 @@ def _check_apoc_mdo_feature_recommendation(result: dict) -> list[str]:
     errors = []
     for phrase in (
         "mdo", "organoid", "large structures", "1, 2, 5, 10, and 25 pixels",
-        "probability-map preview",
+        "probability-map preview", "show classifier statistics", "greener", "redder",
     ):
         if phrase not in text:
             errors.append(f"missing MDO Tune Features recommendation: {phrase}")
@@ -2451,6 +2540,44 @@ def _check_contact_and_dead_threshold(result: dict) -> list[str]:
         errors.append("misstated the 1.01 µm contact scale")
     if result["calls"]:
         errors.append("attempted a threshold edit without a requested value")
+    return errors
+
+
+def _check_first_dead_threshold_preview(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "preview dead threshold in viewer", "select the sample and population",
+        "green is below the threshold", "red is above it", "hovering",
+        "universal numeric range", "re-run feature extraction",
+    ):
+        if phrase not in text:
+            errors.append(f"missing first-time death-threshold workflow: {phrase}")
+    if any(phrase in text for phrase in (
+        "let me open", "i'll open", "i will open", "try opening",
+        "30% is fine", "start at 2%",
+    )):
+        errors.append("claimed an unsupported result opening or invented a threshold")
+    if result["calls"]:
+        errors.append("attempted to open a result or change a threshold")
+    return errors
+
+
+def _check_failed_result_opening_correction(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "no result was opened", "listed as viewable does not mean it has opened",
+        "results", "preview dead threshold in viewer",
+    ):
+        if phrase not in text:
+            errors.append(f"missing failed-opening correction: {phrase}")
+    if any(phrase in text for phrase in (
+        "let me open", "try opening", "i'll open", "i will open",
+    )):
+        errors.append("repeated the unsupported result-opening claim")
+    if result["calls"]:
+        errors.append("retried a result action after the user reported failure")
     return errors
 
 
@@ -2871,6 +2998,26 @@ def _check_historical_calcium_example(result: dict) -> list[str]:
     return errors
 
 
+def _check_historical_microglia_example(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "exp91", "eight wells", "1.77 µm", "120-second", "none_none",
+        "apoc probability map + watershed", "maximum search radius 150",
+        "absolute increase of 30", "start offset", "yaml", "readme", "n=1",
+        "historical values, not defaults",
+    ):
+        if phrase not in text:
+            errors.append(f"missing Exp91 reference detail: {phrase}")
+    if not all(value in text for value in ("0", "1")):
+        errors.append("did not preserve both sides of the Start offset conflict")
+    if not any(term in text for term in ("descriptive", "exploratory")):
+        errors.append("omitted the unreplicated-design interpretation caveat")
+    if result["calls"]:
+        errors.append("attempted to apply historical Exp91 values")
+    return errors
+
+
 def _check_experiment_reference_metadata_conflict(result: dict) -> list[str]:
     text = result["text"].lower()
     errors = []
@@ -2923,6 +3070,8 @@ SCENARIOS = [
     _segmentation_minimum_size_case,
     _mask_edt_direction_case,
     _contact_and_dead_threshold_case,
+    _first_dead_threshold_preview_case,
+    _failed_result_opening_correction_case,
     _loaded_metadata_not_unsaved_case,
     _external_zarr_reload_case,
     _missing_log_error_case,
@@ -2947,6 +3096,7 @@ SCENARIOS = [
     _safety_profiling_context_case,
     _historical_btrack_examples_case,
     _historical_calcium_example_case,
+    _historical_microglia_example_case,
     _experiment_reference_metadata_conflict_case,
 ]
 

--- a/chatbot/smoke_test.py
+++ b/chatbot/smoke_test.py
@@ -1834,6 +1834,25 @@ def _choose_analysis_case() -> dict:
     }
 
 
+def _analysis_question_on_metadata_tab_case() -> dict:
+    return {
+        "name": "analysis_question_is_not_hijacked_by_metadata_clarification",
+        "messages": [{
+            "role": "user",
+            "content": (
+                "I have an experiment with T cells, Macrophages and Organoids of "
+                "different lines. What analysis would be possible for this data?"
+            ),
+        }],
+        "context": _context(
+            "data_preparation", [],
+            metadata={"loaded": False, "records": [], "validation": []},
+            metadata_builder={"open": False, "sample_forms_created": False},
+        ),
+        "check": _check_analysis_question_on_metadata_tab,
+    }
+
+
 def _metadata_not_added_case() -> dict:
     control_id = "metadata.samples.0.cell_types.Macrophages.line"
     return {
@@ -1898,11 +1917,13 @@ def _check_metadata_identifier_confirmation(result: dict) -> list[str]:
     text = result["text"].lower()
     errors = []
     for phrase in (
-        "well", "mandatory", "condition is optional", "m21/m23",
-        "not added", "not_added",
+        "well", "mandatory", "condition is optional", "filenames", "not_added",
     ):
         if phrase not in text:
             errors.append(f"missing identifier guidance: {phrase}")
+    for experiment_value in ("m21", "m23", "gd2_cart"):
+        if experiment_value in text:
+            errors.append(f"embedded experiment-specific identifier: {experiment_value}")
     if result["calls"]:
         errors.append("filled filename-derived values before confirmation")
     return errors
@@ -1953,7 +1974,8 @@ def _check_choose_analysis(result: dict) -> list[str]:
     errors = []
     for phrase in (
         "death dynamics", "interaction analysis", "invasiveness analysis",
-        "active killing", "behavioral state", "state trajectory", "backprojection",
+        "active killing", "behavioral state", "state trajectory",
+        "contact-based grouping", "contact state-shift analysis", "backprojection",
     ):
         if phrase not in text:
             errors.append(f"did not explain {phrase}")
@@ -1962,6 +1984,23 @@ def _check_choose_analysis(result: dict) -> list[str]:
             errors.append(f"did not ground the recommendation in metadata: {phrase}")
     if result["calls"]:
         errors.append("Choose analysis navigated instead of explaining options")
+    return errors
+
+
+def _check_analysis_question_on_metadata_tab(result: dict) -> list[str]:
+    text = result["text"].lower()
+    errors = []
+    for phrase in (
+        "no metadata is loaded", "interaction analysis", "invasiveness analysis",
+        "contact-based grouping", "contact state-shift analysis",
+    ):
+        if phrase not in text:
+            errors.append(f"missing analysis overview detail: {phrase}")
+    for hijack in ("before i build the metadata", "separate organoid types"):
+        if hijack in text:
+            errors.append(f"analysis question was hijacked by metadata prompt: {hijack}")
+    if result["calls"]:
+        errors.append("analysis overview attempted an action")
     return errors
 
 
@@ -2859,6 +2898,7 @@ SCENARIOS = [
     _metadata_completion_case,
     _metadata_save_case,
     _choose_analysis_case,
+    _analysis_question_on_metadata_tab_case,
     _metadata_not_added_case,
     _open_death_dynamics_case,
     _metadata_setup_case,

--- a/docs/source/assistant/reference_experiment_profiles.md
+++ b/docs/source/assistant/reference_experiment_profiles.md
@@ -129,6 +129,72 @@ Use this profile to explain why intensity can be the primary behavioral signal
 when propagation makes movement and morphology nearly constant. Do not use its
 HMM feature set for motility experiments.
 
+## Exp91 DMG organoid, macrophage/microglia, and GD2 CAR-T co-culture
+
+**Evidence:** `README_BEHAV3D_BRIM_AW1_DMG_microglia_Exp91.md`,
+`metadata.csv`, and `behav3d_parameters.yml` supplied for Exp91.
+
+- Eight wells combine one DMG/DIPG organoid line per movie, optional
+  macrophage/microglia, and the same GD2 CAR-T product. Organoid lines are
+  `BT-093_WT` (DO7), its GD2-knockout control `BT-093_KO_WT` (DO7_KO), and
+  the independent patient line `DIPG002ns_WT`. Macrophage/microglia conditions
+  are no added cells, `M21_WT`, and `M23_WT`.
+- The matrix is intentionally incomplete: `DIPG002ns_WT` has no M21 condition.
+  Every included organoid-line by macrophage-condition combination has one well,
+  so biological comparisons are descriptive or exploratory rather than powered
+  replicate-level tests.
+- The CSV records 1.77 um isotropic sampling, 120 s frames, `TCZYX`, and five
+  raw channels: brightfield 0, T cell 1, macrophage/microglia 2, dead-cell dye 3,
+  and organoid 4. The README reports 437 timepoints.
+- One `organoid` processing type is used because only one organoid line occurs
+  in each movie. Organoid identity is stored as its per-sample line. Grouping by
+  organoid type therefore does not separate the three biological lines; exported
+  data must be subset by organoid line or the analysis run per line subset.
+- The historical CSV uses `None_None` for no macrophage/microglia added. In those
+  wells, macrophage segment and track paths still exist because the channel was
+  processed uniformly, but the README confirms that detections are noise. The
+  line value, not path presence, is authoritative. For newly built metadata, use
+  the current UI's `not added` representation rather than copying this legacy
+  sentinel.
+- The saved APOC strategy is Probability Map + Watershed. Organoid input uses
+  channels 3 and 4; macrophage uses 2; T cell uses 1; dead uses 3. Saved
+  mask/seed thresholds are 0.5/0.8 for organoids and 0.5/0.6 for macrophages and
+  T cells. Saved minimum sizes are 1000, 100, and 30 voxels respectively.
+- Organoid features use sigma 1, 2, 5, and 15; macrophage and T-cell features use
+  1, 2, and 5. A broader organoid candidate grid from 0.3 through 25 is also
+  saved. Treat those as candidate features: train, inspect Show classifier
+  statistics, remove consistently low-importance features, then retrain and
+  preview.
+- Organoids and macrophages use Propagation. The README explains that the
+  macrophages were mostly stationary/adherent and that changing protrusions
+  fragmented their masks, making propagation more reliable than centroid-based
+  identity assignment. T cells use btrack with maximum search radius 150,
+  global optimization, optimizer distance 100, time threshold 5 frames, and
+  step size 100.
+- Feature extraction uses direct contact at 0 um. Saved death thresholds are 3%
+  for organoids and 30% for macrophages and T cells. Both immune populations
+  include invasiveness. Organoid filtering uses minimum length 100 and initial
+  size 2000; macrophage filtering is effectively disabled; T cells use minimum
+  length 5 without maximum-length filtering or splitting.
+- Active Killing uses dead-mask pixel count in absolute mode: an increase of 30
+  pixels within 5 frames (10 min) after at least one contact frame. The saved
+  1.5 multiplier is inactive in absolute mode.
+- Only T cells have behavioral analysis configured: a four-state HMM using
+  morphology and motion, plus 5-frame net displacement and straightness. Binary
+  groups include death, active killing, and organoid contact; macrophage contact
+  is deliberately reserved for downstream contact analyses. Trajectory analysis
+  uses 50-timepoint windows, splitting at analysis time, nine requested clusters,
+  Average linkage, and the last-window trim mode.
+- Source conflict: the YAML saves HMM Start offset 0, while the README says Start
+  offset 1. Report both values and ask which source represents the finalized run;
+  do not silently reconcile them.
+
+Use this profile for macrophage/microglia effects on CAR-T behavior, antigen
+specificity using the GD2-knockout control, donor comparisons, invasiveness, and
+contact-associated killing. Keep the n=1 and incomplete-matrix caveats attached
+to every comparison, and never transfer its thresholds or tracking values to a
+new microglia experiment solely because the population names match.
+
 ## Method-level lessons from the integrated Methods description
 
 - Method choice follows signal quality, object morphology, compute, and whether

--- a/docs/source/processing/segmentation/apoc.md
+++ b/docs/source/processing/segmentation/apoc.md
@@ -156,6 +156,11 @@ More checked channels → more feature columns and slower runs; keep the set tha
 
 After training, **Show classifier statistics** opens a table of **feature importance** (one row per filter×sigma×channel combination, e.g. `difference_of_gaussian_sigma2_channel0`). Higher importance means the forest relied on that column more when splitting.
 
+The Importance cells are color-coded from **green (more informative)** toward
+**red (less informative)**. Start with the proposed preset and, when object scale
+is uncertain, a broader candidate set; then use this table to remove consistently
+low-importance rows before retraining and checking the probability-map preview.
+
 - **One row dominates** (much higher than the rest). Often the classifier found one strong cue (e.g. a T-cell channel at σ `2`). It is a problem if preview looks **overfitted** to your painted labels, or if importance is high on a **noisy or artefact** channel you should disable.
 - **Many rows near zero** → safe to uncheck those filter×sigma boxes in *Tune Features* (or drop channels) and retrain for a faster, leaner model.
 - **Dominating filter** means a **specific row in the grid** (e.g. `DoG` at σ `1`). Fix by unchecking that row if it is redundant, or by fixing labels/channels if the model is latching onto the wrong cue.

--- a/test/fixtures/assistant_feedback_transcripts.json
+++ b/test/fixtures/assistant_feedback_transcripts.json
@@ -203,8 +203,9 @@
       "complete is a reasonable comparison",
       "single linkage performs poorly",
       "original behav3d feature-based mode is deprecated",
-      "contact-based comparison plots",
-      "exemplar track"
+      "categorical dtw supports contact-based grouping",
+      "contact state-shift analysis",
+      "requires behavioral state results"
     ]
   },
   {
@@ -279,8 +280,11 @@
       "active killing",
       "behavioral state",
       "state trajectory",
+      "contact-based grouping",
+      "contact state-shift analysis",
       "backprojection"
-    ]
+    ],
+    "forbidden": ["contact-based comparison plots are currently known to produce empty output"]
   },
   {
     "id": "metadata_does_not_own_channel_mapping",

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -472,6 +472,33 @@ def test_organoid_lines_require_processing_group_confirmation():
     assert app.organoid_processing_question(context, messages) is None
 
 
+def test_analysis_question_on_metadata_tab_is_not_hijacked_by_organoid_setup():
+    import app
+
+    context = {
+        "current_step": "data_preparation",
+        "metadata": {"loaded": False, "records": []},
+        "metadata_builder": {"sample_forms_created": False},
+    }
+    messages = [{
+        "role": "user",
+        "content": (
+            "I have an experiment with T cells, Macrophages and Organoids of "
+            "different lines. What analysis would be possible for this data?"
+        ),
+    }]
+    assert app.organoid_processing_question(context, messages) is None
+    result = app.deterministic_turn_response(context, messages, [])
+    text = result["text"]
+    assert "No metadata is loaded" in text
+    assert "Interaction Analysis" in text
+    assert "Invasiveness Analysis" in text
+    assert "Contact-Based Grouping" in text
+    assert "Contact State-Shift Analysis" in text
+    assert "Before I build the metadata" not in text
+    assert "separate organoid types" not in text
+
+
 def test_metadata_completion_uses_mandatory_well_and_line_fields():
     import app
 
@@ -509,10 +536,18 @@ def test_metadata_identifier_inferences_require_confirmation():
     )
     assert "mandatory" in response
     assert "condition is optional" in response
-    assert "M21/M23" in response
     assert "not_added" in response
-    assert "not added" in response
     assert "confirm" in response
+    assert "filenames" in response
+    assert "M21" not in response and "M23" not in response
+    assert "GD2" not in response
+
+    missing_lines = app.metadata_identifier_confirmation_question(
+        {"metadata_builder": {"sample_forms_created": True}},
+        [{"role": "user", "content": "I have not specified lines yet."}],
+    )
+    assert "line for every configured" in missing_lines
+    assert "not_added" in missing_lines
 
 
 def test_metadata_time_conversion_updates_every_sample_without_stale_action():
@@ -575,6 +610,7 @@ def test_analysis_choose_explains_and_named_view_opens_directly():
         {
             "assistant_session": {"intent": "choose_analysis"},
             "metadata": {
+                "loaded": True,
                 "n_samples": 8,
                 "cell_types": {
                     "organoid": ["Organoids"],
@@ -593,12 +629,14 @@ def test_analysis_choose_explains_and_named_view_opens_directly():
     )
     for name in (
         "Death Dynamics", "Interaction Analysis", "Invasiveness Analysis",
-        "Active Killing", "Behavioral State", "State Trajectory", "Backprojection",
+        "Active Killing", "Behavioral State", "State Trajectory",
+        "Contact-Based Grouping", "Contact State-Shift Analysis", "Backprojection",
     ):
         assert name in summary
     assert "8 samples" in summary
     assert "DO7" in summary and "GD2_CART" in summary and "M21" in summary
     assert "Questions suggested by your metadata" in summary
+    assert "Categorical DTW" in summary
 
     action = app.analysis_navigation_action(
         {"current_step": "analysis", "analysis": {"view": "behavioral_state"}},
@@ -3089,7 +3127,7 @@ def test_feedback_guidance_fixtures():
 
     fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
     cases = json.loads(fixture.read_text(encoding="utf-8"))
-    assert KNOWLEDGE_VERSION == "2026.07.27.25"
+    assert KNOWLEDGE_VERSION == "2026.07.27.27"
     for case in cases:
         cards = select_guidance_cards(
             {"current_step": case["step"]}, case["user"], case.get("intent"))

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -1229,8 +1229,10 @@ def test_metadata_channel_mapping_stays_out_of_metadata_builder():
     result = app.metadata_channel_mapping_guidance({}, messages)
     assert "does not map raw channel indices" in result
     assert "line" in result.lower()
-    assert "cellpose controls as metadata fields" in result.lower()
-    assert "same for all" not in result.lower()
+    assert "convpaint" in result.lower()
+    assert "shared multiclass model" in result.lower()
+    assert "not independent per sample" in result.lower()
+    assert "i should not" not in result.lower()
 
 
 def test_apoc_channel_guidance_rejects_invalid_index_and_dead_negative_class():
@@ -1315,6 +1317,11 @@ def test_apoc_feature_grid_guidance_names_real_filters_and_scope():
     ):
         assert phrase.lower() in result.lower()
     assert "present in the current live apoc controls" in result.lower()
+    for phrase in (
+        "Show classifier statistics", "greener, more informative",
+        "redder, less informative", "broader candidate set",
+    ):
+        assert phrase.lower() in result.lower()
 
 
 def test_apoc_feature_grid_follow_up_recommends_organoid_preset():
@@ -1604,6 +1611,51 @@ def test_contact_distance_guidance_uses_xy_pixel_not_diagonal():
     assert "one-pixel xy gap" in result.lower()
     assert "green is below" in result.lower()
     assert "universal numeric range" in result.lower()
+
+
+def test_dead_threshold_guidance_prioritizes_the_live_viewer_preview():
+    import app
+
+    result = app.feature_threshold_guidance(
+        {
+            "current_step": "feature_extraction",
+            "active_cell_type": "tcell",
+            "results": [{
+                "id": "analysis/tcell/BEHAV3D_dead_dye_distribution.pdf",
+                "label": "Dead dye distribution",
+                "viewable": True,
+            }],
+        },
+        [{"role": "user", "content": (
+            "How should I set the dead-mask percentage threshold for the first time?"
+        )}],
+    )
+    text = result.lower()
+    assert "preview dead threshold in viewer" in text
+    assert "green is below the threshold" in text
+    assert "red is above it" in text
+    assert "hovering" in text
+    assert "universal numeric range" in text
+    assert "let me open" not in text
+    assert "result pdf" in text
+
+
+def test_result_opening_correction_stops_repeated_opening_claims():
+    import app
+
+    result = app.result_opening_correction(
+        {"current_step": "feature_extraction"},
+        [
+            {"role": "user", "content": "How do I set the dead threshold?"},
+            {"role": "assistant", "content": "Let me open the result PDF."},
+            {"role": "user", "content": "I think you cannot open it."},
+        ],
+    )
+    text = result.lower()
+    assert "no result was opened" in text
+    assert "listed as viewable does not mean it has opened" in text
+    assert "preview dead threshold in viewer" in text
+    assert "let me" not in text
 
 
 def test_interface_capabilities_report_current_exposure_without_cross_module_mapping():
@@ -2069,6 +2121,25 @@ def test_historical_reference_guidance_preserves_provenance_and_calibration():
         assert phrase.lower() in calcium["text"].lower()
     assert calcium["calls"] == []
 
+    microglia = app.historical_reference_guidance(
+        {},
+        [{
+            "role": "user",
+            "content": (
+                "What settings and design were used in the previous microglia "
+                "Exp91 experiment?"
+            ),
+        }],
+    )
+    for phrase in (
+        "Exp91", "eight wells", "1.77 µm", "120-second", "None_None",
+        "APOC Probability Map + Watershed", "maximum search radius 150",
+        "absolute increase of 30", "Start offset **0**", "README",
+        "n=1", "historical values, not defaults",
+    ):
+        assert phrase.lower() in microglia["text"].lower()
+    assert microglia["calls"] == []
+
 
 def test_prompt_encodes_pi_feedback_scenarios():
     import app
@@ -2119,6 +2190,9 @@ def test_prompt_encodes_pi_feedback_scenarios():
     assert "assigning the same name to multiple primary clusters merges them" in sp
     assert "Death Dynamics, Interaction Analysis, Invasiveness Analysis" in sp
     assert "line to the literal CSV-safe value 'not_added'" in sp
+    assert "Never narrate internal rules" in sp
+    assert "Opening a result requires an open_result call" in sp
+    assert "A result merely listed as viewable has not been opened" in sp
 
 
 class _FakeSpin:
@@ -3127,7 +3201,7 @@ def test_feedback_guidance_fixtures():
 
     fixture = Path(__file__).parent / "fixtures" / "assistant_feedback_transcripts.json"
     cases = json.loads(fixture.read_text(encoding="utf-8"))
-    assert KNOWLEDGE_VERSION == "2026.07.27.27"
+    assert KNOWLEDGE_VERSION == "2026.07.27.28"
     for case in cases:
         cards = select_guidance_cards(
             {"current_step": case["step"]}, case["user"], case.get("intent"))


### PR DESCRIPTION
## Summary

- tighten deterministic intent routing so metadata-specific prompts do not override general analysis questions
- keep metadata identifiers experiment-neutral and expand the analysis overview to include the current Death Dynamics, interaction, invasiveness, and contact-based analyses
- correct swapped-channel guidance and distinguish per-population models from ConvPaint's shared multiclass channel selection
- guide APOC feature tuning through classifier statistics, feature-importance colors, retraining, and visual previews
- prioritize the built-in dead-threshold viewer preview and stop repeated claims that a result was opened when no opening action occurred
- add a provenance-labelled Exp91 DMG organoid/macrophage-microglia/GD2 CAR-T reference profile, including the incomplete n=1 design, legacy absence marker, and YAML/README Start offset discrepancy
- extend the deterministic and deployed-API regression scenarios for the new feedback

## Why

Several broad user questions were being captured by overly permissive predetermined responses. Other answers mixed controls or assumptions across segmentation methods, exposed internal policy wording, skipped the available dead-threshold preview, or claimed to open result files without issuing an action. Historical experiment values also needed stronger source attribution and explicit conflict/caveat handling so they could be useful examples without becoming defaults.

## Impact

Researchers now receive answers scoped to the actual question, active module, method, and live controls. The assistant gives a concrete visual calibration workflow where one exists, asks for clarification when evidence is missing, and treats Exp91 values as sourced historical context rather than settings to copy automatically.

## Validation

- `python -m py_compile chatbot/app.py chatbot/guidance.py chatbot/smoke_test.py`
- `conda run -n behav3d python test/test_assistant.py`: 104/104 passed
- targeted deployed feedback scenarios: 7/7 passed
- complete deployed API suite: 58/59 passed initially; the only failure was an incomplete DeepSeek streamed response, and the isolated retry passed, covering all 59 scenarios
- actual supplied Exp91 directory loaded successfully through the runtime experiment-reference loader
- Modal production health verified with knowledge version `2026.07.27.28` and rebuilt 971-chunk RAG index
