### PR TITLE
Add assistant service diagnostics and automatic recovery

### DIFF
--- a/behav3d/napari/_assistant.py
+++ b/behav3d/napari/_assistant.py
@@ -17,6 +17,7 @@ All network I/O happens on a QThread worker (``ChatWorker``); the GUI never bloc
 """
 from __future__ import annotations
 
+import time
 from typing import Optional
 
 from qtpy.QtCore import Qt, QThread, QTimer, Signal
@@ -29,7 +30,9 @@ from behav3d.napari._assistant_context import build_context, context_summary_lin
 from behav3d.napari._assistant_actions import (
     build_actions, apply_action, TOOL_SCHEMA, ProposedAction, humanize_parameter_key,
 )
-from behav3d.napari._assistant_client import ChatWorker, load_client_config
+from behav3d.napari._assistant_client import (
+    ChatWorker, HealthWorker, load_client_config,
+)
 
 
 _UNSET = object()  # sentinel for "parameter not yet in config"
@@ -242,12 +245,16 @@ def researcher_facing_text(text: str) -> str:
     return result.replace("`", "")
 
 
-def streaming_transcript_block(request_active: bool, streaming_text: str | None) -> str | None:
+def streaming_transcript_block(
+    request_active: bool,
+    streaming_text: str | None,
+    status_message: str | None = None,
+) -> str | None:
     """Return the visible assistant block while a request is in progress."""
     if streaming_text is None:
         return None
     body = streaming_text or (
-        "*Preparing a response...*" if request_active else ""
+        f"*{status_message or 'Preparing a response...'}*" if request_active else ""
     )
     if not body:
         return None
@@ -344,6 +351,16 @@ class AssistantDock(QWidget):
         self._md_phase: str | None = None
         self._current_intent: str = "free_form"
         self._request_active = False
+        self._request_outcome = "idle"
+        self._status_info: dict = {
+            "level": "checking",
+            "stage": "startup",
+            "message": "Checking the assistant service...",
+        }
+        self._status_started = time.monotonic()
+        self._health_check_active = False
+        self._health_check_background = False
+        self._recovery_probe_provider = False
         # Coalesce streamed-token re-renders. Re-rendering the whole transcript on
         # every token saturates the GUI thread on long answers (the napari window
         # freezes until the stream ends). This single-shot timer batches tokens into
@@ -353,6 +370,13 @@ class AssistantDock(QWidget):
         self._render_timer.setSingleShot(True)
         self._render_timer.setInterval(90)
         self._render_timer.timeout.connect(self._render_streaming)
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(1000)
+        self._status_timer.timeout.connect(self._refresh_status_label)
+        self._recovery_timer = QTimer(self)
+        self._recovery_timer.setSingleShot(True)
+        self._recovery_timer.setInterval(15000)
+        self._recovery_timer.timeout.connect(self._run_recovery_check)
 
         # Cohesive dark-theme styling for the whole dock (matches napari surfaces).
         self.setStyleSheet("""
@@ -403,10 +427,22 @@ class AssistantDock(QWidget):
         context_row.addWidget(self.btn_new_chat)
         root.addLayout(context_row)
 
-        self.status_label = QLabel("")
-        self.status_label.setStyleSheet("color:#9aa4aa; font-size:11px; padding:0 2px;")
-        self.status_label.setVisible(False)
-        root.addWidget(self.status_label)
+        status_row = QHBoxLayout()
+        status_row.setSpacing(6)
+        self.status_label = QLabel("Checking the assistant service...")
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color:#9fc6e0; font-size:11px; padding:0 2px;")
+        status_row.addWidget(self.status_label, stretch=1)
+        self.btn_check_status = QPushButton("Check status")
+        self.btn_check_status.setToolTip(
+            "Test Modal, the BEHAV3D guidance index, and DeepSeek"
+        )
+        self.btn_check_status.setStyleSheet("padding:4px 7px; font-size:10px;")
+        self.btn_check_status.clicked.connect(
+            lambda: self._check_service_status(probe_provider=True)
+        )
+        status_row.addWidget(self.btn_check_status)
+        root.addLayout(status_row)
         self.thinking_progress = QProgressBar()
         self.thinking_progress.setRange(0, 0)
         self.thinking_progress.setTextVisible(False)
@@ -456,6 +492,13 @@ class AssistantDock(QWidget):
         except Exception:
             initial_idx = 0
         self._set_quick_buttons(initial_idx)
+        self._refresh_status_label()
+        QTimer.singleShot(
+            0,
+            lambda: self._check_service_status(
+                probe_provider=False, background=True
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Context bar
@@ -475,6 +518,135 @@ class AssistantDock(QWidget):
             "values suit your data. I can also fill the forms in for you "
             "(you confirm first). Try *“Explain this screen”* to start, or ask "
             "*“Is all ready?”* before running the steps."
+        )
+
+    # ------------------------------------------------------------------
+    # Service diagnostics
+    # ------------------------------------------------------------------
+    def _set_service_status(self, info: dict):
+        self._status_info = dict(info or {})
+        self._status_started = time.monotonic()
+        level = self._status_info.get("level", "working")
+        colors = {
+            "online": "#82c995",
+            "checking": "#9fc6e0",
+            "working": "#9fc6e0",
+            "degraded": "#f2c078",
+            "offline": "#ffb070",
+            "error": "#ff9b9b",
+        }
+        self.status_label.setStyleSheet(
+            f"color:{colors.get(level, '#9aa4aa')}; font-size:11px; padding:0 2px;"
+        )
+        self._refresh_status_label()
+
+        details = []
+        labels = {
+            "modal": "Modal",
+            "deepseek": "DeepSeek",
+            "retrieval": "BEHAV3D guidance",
+            "model": "Model",
+            "chunks": "Guidance chunks",
+            "latency_ms": "Health latency",
+            "provider_latency_ms": "DeepSeek latency",
+            "provider_error": "DeepSeek error",
+            "request_id": "Request ID",
+            "code": "Status code",
+            "endpoint": "Endpoint",
+        }
+        for key, label in labels.items():
+            value = self._status_info.get(key)
+            if value not in (None, ""):
+                suffix = " ms" if key.endswith("latency_ms") else ""
+                details.append(f"{label}: {value}{suffix}")
+        self.status_label.setToolTip("\n".join(details))
+
+        if level == "online":
+            self._recovery_timer.stop()
+            self._recovery_probe_provider = False
+        elif level in {"offline", "error"}:
+            code = self._status_info.get("code")
+            if code != "endpoint_missing":
+                self._recovery_probe_provider = (
+                    self._recovery_probe_provider
+                    or self._status_info.get("component") == "deepseek"
+                    or str(code).startswith(("deepseek", "provider"))
+                )
+                if not self._recovery_timer.isActive():
+                    self._recovery_timer.start()
+
+    def _refresh_status_label(self):
+        info = self._status_info or {}
+        level = info.get("level", "working")
+        message = info.get("message") or "Assistant status unavailable."
+        prefixes = {
+            "online": "Online",
+            "degraded": "Limited",
+            "offline": "Offline",
+            "error": "Issue",
+        }
+        prefix = prefixes.get(level)
+        text = f"{prefix} · {message}" if prefix else message
+        if self._request_active and level in {"checking", "working", "degraded"}:
+            elapsed = max(0, int(time.monotonic() - self._status_started))
+            text = f"{text} ({elapsed}s)"
+        self.status_label.setText(text)
+
+    def _check_service_status(
+        self,
+        *,
+        probe_provider: bool = True,
+        background: bool = False,
+    ):
+        if self._health_check_active:
+            return
+        self._health_check_active = True
+        self._health_check_background = bool(background)
+        self.btn_check_status.setEnabled(False)
+        self.btn_check_status.setText("Checking...")
+        if not background or self._status_info.get("level") in {"offline", "error"}:
+            self._set_service_status({
+                "level": "checking",
+                "stage": "health",
+                "component": "service",
+                "message": (
+                    "Checking Modal, BEHAV3D guidance, and DeepSeek..."
+                    if probe_provider else
+                    "Checking Modal and BEHAV3D guidance..."
+                ),
+            })
+
+        worker = HealthWorker(probe_provider=probe_provider)
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.result.connect(self._on_health_result)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(
+            lambda: self._on_health_finished(thread, worker)
+        )
+        self._threads.append((thread, worker))
+        thread.start()
+
+    def _on_health_result(self, info: dict):
+        if self._request_active and self._health_check_background:
+            return
+        self._set_service_status(info)
+
+    def _on_health_finished(self, thread, worker):
+        self._health_check_active = False
+        self._health_check_background = False
+        self.btn_check_status.setEnabled(True)
+        self.btn_check_status.setText("Check status")
+        self._cleanup_thread(thread, worker)
+
+    def _run_recovery_check(self):
+        if self._health_check_active:
+            self._recovery_timer.start()
+            return
+        self._check_service_status(
+            probe_provider=self._recovery_probe_provider,
+            background=True,
         )
 
     def _reset_conversation(self):
@@ -521,7 +693,9 @@ class AssistantDock(QWidget):
         self._render_timer.stop()
         blocks = list(self._md_log)
         streaming = streaming_transcript_block(
-            self._request_active, self._streaming_text
+            self._request_active,
+            self._streaming_text,
+            (self._status_info or {}).get("message"),
         )
         if streaming:
             blocks.append(streaming)
@@ -648,6 +822,7 @@ class AssistantDock(QWidget):
         # Keep only the latest 12 user/assistant exchanges. Session facts and live
         # values are carried separately in structured context.
         self._history = self._history[-24:]
+        self._request_outcome = "pending"
         self._set_busy(True)
         self._streaming_text = ""        # opens a live "Assistant:" block
         self._render()
@@ -668,6 +843,7 @@ class AssistantDock(QWidget):
         thread.started.connect(worker.run)
         worker.token.connect(self._on_token)
         worker.tool_calls.connect(self._on_tool_calls)
+        worker.status.connect(self._on_worker_status)
         worker.degraded.connect(self._on_degraded)
         worker.error.connect(self._on_error)
         worker.finished.connect(thread.quit)
@@ -680,9 +856,19 @@ class AssistantDock(QWidget):
         self._request_active = bool(busy)
         self.btn_send.setEnabled(not busy)
         self.btn_new_chat.setEnabled(not busy)
-        self.status_label.setText("Assistant is thinking..." if busy else "")
-        self.status_label.setVisible(bool(busy))
         self.thinking_progress.setVisible(bool(busy))
+        if busy:
+            self._recovery_timer.stop()
+            self._set_service_status({
+                "level": "working",
+                "stage": "connecting",
+                "component": "modal",
+                "message": "Connecting to Modal...",
+            })
+            self._status_timer.start()
+        else:
+            self._status_timer.stop()
+            self._refresh_status_label()
         # Leave the input box editable while a turn is in flight so the user can
         # type their next answer without waiting for the stream to finish.
         for i in range(self._quick_layout.count()):
@@ -697,6 +883,14 @@ class AssistantDock(QWidget):
     # ------------------------------------------------------------------
     # Worker signal handlers
     # ------------------------------------------------------------------
+    def _on_worker_status(self, info: dict):
+        level = (info or {}).get("level")
+        if level in {"offline", "error"}:
+            self._request_outcome = level
+        self._set_service_status(info)
+        if self._request_active and not self._streaming_text:
+            self._render(style=False)
+
     def _on_token(self, chunk: str):
         if self._streaming_text is None:
             self._streaming_text = ""
@@ -707,13 +901,20 @@ class AssistantDock(QWidget):
         self._schedule_render()
 
     def _on_degraded(self, full_text: str):
+        self._request_outcome = "offline"
         self._streaming_text = researcher_facing_text(full_text)
         self._render()
 
     def _on_error(self, message: str):
+        self._request_outcome = "error"
         # close any open streaming block, then show the error
         self._finalize_streaming()
-        self._append_md(message)
+        request_id = (self._status_info or {}).get("request_id")
+        support_ref = f"\n\nRequest ID: `{request_id}`" if request_id else ""
+        self._append_md(
+            f"**Request failed**\n\n{message}{support_ref}\n\n"
+            "The assistant will keep checking for recovery automatically."
+        )
         # Defensive: ensure the dock never stays stuck "thinking" if signal
         # ordering ever changes (worker.finished still clears busy too).
         self._set_busy(False)
@@ -950,6 +1151,15 @@ class AssistantDock(QWidget):
         self._finalize_streaming()
         self._render()
         self._set_busy(False)
+        if self._request_outcome not in {"offline", "error"}:
+            self._request_outcome = "complete"
+            self._set_service_status({
+                "level": "online",
+                "stage": "complete",
+                "component": "service",
+                "message": "Response completed.",
+                "request_id": (self._status_info or {}).get("request_id"),
+            })
         if had_text:
             self._append_log()
 

--- a/behav3d/napari/_assistant.py
+++ b/behav3d/napari/_assistant.py
@@ -579,8 +579,16 @@ class AssistantDock(QWidget):
         info = self._status_info or {}
         level = info.get("level", "working")
         message = info.get("message") or "Assistant status unavailable."
+        if level == "online":
+            fully_checked = (
+                info.get("deepseek") == "online"
+                or info.get("stage") == "complete"
+            )
+            self.status_label.setText(
+                "Online · All systems working" if fully_checked else "Online"
+            )
+            return
         prefixes = {
-            "online": "Online",
             "degraded": "Limited",
             "offline": "Offline",
             "error": "Issue",

--- a/behav3d/napari/_assistant_client.py
+++ b/behav3d/napari/_assistant_client.py
@@ -12,6 +12,7 @@ Wire protocol (client → server):  POST {endpoint}/chat
       "tools":    <TOOL_SCHEMA>,
     }
 Server → client: an SSE / newline-delimited-JSON stream of events:
+    {"type": "status",     "stage": "provider", "message": "..."}
     {"type": "token",      "text": "..."}        # streamed assistant text
     {"type": "tool_calls", "calls": [ {name, arguments}, ... ]}
     {"type": "done"}
@@ -26,8 +27,8 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
-from typing import Optional
 
 from qtpy.QtCore import QObject, Signal
 
@@ -53,6 +54,204 @@ def load_client_config() -> dict:
     token = os.environ.get("BEHAV3D_ASSISTANT_TOKEN", cfg.get("token", ""))
     return {"endpoint": endpoint.rstrip("/"), "token": token,
             "timeout": cfg.get("timeout", 45)}
+
+
+def _configured_read_timeout(config: dict) -> float:
+    timeout = config.get("timeout", 45)
+    if isinstance(timeout, (tuple, list)):
+        timeout = timeout[-1]
+    try:
+        return max(1.0, float(timeout))
+    except (TypeError, ValueError):
+        return 45.0
+
+
+def classify_request_failure(
+    error: Exception,
+    *,
+    stage: str = "connecting",
+    read_timeout: float = 45,
+) -> dict:
+    """Turn transport exceptions into component-specific, user-facing status."""
+    error_name = type(error).__name__
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+
+    if error_name == "ConnectTimeout":
+        return {
+            "level": "offline",
+            "stage": "modal",
+            "component": "modal",
+            "code": "modal_connect_timeout",
+            "message": (
+                "Modal did not respond within 10 seconds. The service may be "
+                "starting or temporarily unavailable."
+            ),
+        }
+    if error_name == "ReadTimeout":
+        seconds = int(read_timeout) if float(read_timeout).is_integer() else read_timeout
+        if stage in {"provider", "streaming"}:
+            message = (
+                f"DeepSeek stopped responding for {seconds} seconds. Modal is reachable, "
+                "but the model response timed out."
+            )
+            component = "deepseek"
+            code = "deepseek_timeout"
+        else:
+            message = (
+                f"Modal was reached but did not send an update for {seconds} seconds."
+            )
+            component = "modal"
+            code = "modal_read_timeout"
+        return {
+            "level": "error",
+            "stage": stage,
+            "component": component,
+            "code": code,
+            "message": message,
+        }
+    if error_name == "ConnectionError":
+        return {
+            "level": "offline",
+            "stage": "modal",
+            "component": "modal",
+            "code": "modal_unreachable",
+            "message": (
+                "Could not reach Modal. Check the internet connection and assistant endpoint."
+            ),
+        }
+    if status_code is not None:
+        return {
+            "level": "error",
+            "stage": "modal",
+            "component": "modal",
+            "code": "modal_http_error",
+            "http_status": int(status_code),
+            "message": f"Modal returned HTTP {status_code} instead of an assistant response.",
+        }
+    if isinstance(error, (json.JSONDecodeError, ValueError)):
+        return {
+            "level": "error",
+            "stage": stage,
+            "component": "modal",
+            "code": "invalid_response",
+            "message": "The assistant service returned an invalid response.",
+        }
+    return {
+        "level": "error",
+        "stage": stage,
+        "component": "unknown",
+        "code": "request_failed",
+        "message": f"The assistant request failed ({error_name}).",
+    }
+
+
+def request_failure_is_retryable(info: dict) -> bool:
+    """Return True for transient failures that are safe to retry before output."""
+    code = str((info or {}).get("code") or "")
+    if code == "modal_http_error":
+        return int((info or {}).get("http_status") or 0) in {429, 502, 503, 504}
+    return code in {
+        "modal_connect_timeout",
+        "modal_read_timeout",
+        "modal_unreachable",
+        "deepseek_timeout",
+        "provider_error",
+    }
+
+
+def diagnose_assistant_service(
+    config: dict | None = None,
+    *,
+    probe_provider: bool = False,
+    requester=None,
+) -> dict:
+    """Check Modal/RAG health and optionally make a minimal DeepSeek request.
+
+    ``requester`` is injectable so the response mapping can be unit-tested without
+    a live endpoint. The normal startup check is lightweight; the explicit UI
+    action sets ``probe_provider=True`` to verify DeepSeek as well.
+    """
+    config = dict(config or load_client_config())
+    endpoint = str(config.get("endpoint") or "").rstrip("/")
+    if not endpoint:
+        return {
+            "level": "offline",
+            "stage": "configuration",
+            "component": "client",
+            "code": "endpoint_missing",
+            "modal": "not_configured",
+            "deepseek": "not_checked",
+            "message": "Assistant endpoint is not configured.",
+        }
+
+    if requester is None:
+        import requests
+        requester = requests.get
+
+    started = time.monotonic()
+    try:
+        response = requester(
+            f"{endpoint}/health",
+            params={"probe_provider": "true"} if probe_provider else None,
+            timeout=(5, min(_configured_read_timeout(config), 30)),
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("health response is not an object")
+    except Exception as error:
+        result = classify_request_failure(
+            error, stage="modal", read_timeout=min(_configured_read_timeout(config), 30)
+        )
+        result.update({
+            "modal": "offline",
+            "deepseek": "not_checked",
+            "latency_ms": round((time.monotonic() - started) * 1000),
+            "endpoint": endpoint,
+        })
+        return result
+
+    service = payload.get("service") or {}
+    retrieval = payload.get("retrieval") or {}
+    provider = payload.get("provider") or {}
+    modal_status = service.get("status", "online" if payload.get("ok") else "error")
+    retrieval_status = retrieval.get(
+        "status", "ready" if int(payload.get("chunks") or 0) > 0 else "empty"
+    )
+    provider_status = provider.get("status", "not_checked")
+    level = "online"
+    if modal_status != "online" or provider_status == "error":
+        level = "error"
+    elif retrieval_status != "ready":
+        level = "degraded"
+
+    if provider_status == "online":
+        message = "Modal, BEHAV3D guidance, and DeepSeek are online."
+    elif provider_status == "error":
+        message = "Modal is online, but the DeepSeek health check failed."
+    elif retrieval_status != "ready":
+        message = "Modal is online, but the BEHAV3D guidance index is unavailable."
+    else:
+        message = "Modal and BEHAV3D guidance are online. DeepSeek was not tested."
+
+    return {
+        "level": level,
+        "stage": "health",
+        "component": "service",
+        "code": "health_check",
+        "message": message,
+        "modal": modal_status,
+        "deepseek": provider_status,
+        "retrieval": retrieval_status,
+        "chunks": retrieval.get("chunks", payload.get("chunks")),
+        "model": payload.get("model"),
+        "knowledge_version": payload.get("knowledge_version"),
+        "provider_latency_ms": provider.get("latency_ms"),
+        "provider_error": provider.get("error_type"),
+        "latency_ms": round((time.monotonic() - started) * 1000),
+        "endpoint": endpoint,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -83,10 +282,9 @@ class LocalResponder:
             scored.sort(key=lambda x: x[0], reverse=True)
             hits = [c for s, c in scored[:3] if s > 0]
         if not hits:
-            return ("⚠️ Offline mode (no assistant server reachable). I can only "
-                    "answer field questions locally. Try asking, for example, "
-                    "“What does search range mean?”")
-        lines = ["⚠️ *Offline mode* — answering from the local parameter schema:\n"]
+            return ("Local help is limited to parameter definitions. Try asking, "
+                    "for example, “What does search range mean?”")
+        lines = ["I can still answer from the local parameter reference:\n"]
         from behav3d.napari._assistant_actions import humanize_parameter_key
         for c in hits[:3]:
             dv = c.get("default")
@@ -106,6 +304,7 @@ class ChatWorker(QObject):
 
     token = Signal(str)            # incremental assistant text
     tool_calls = Signal(object)    # list[dict] of proposed calls
+    status = Signal(object)        # stage/component/message diagnostics
     error = Signal(str)
     degraded = Signal(str)         # emitted (full text) when answered offline
     finished = Signal()            # always last; quits the thread
@@ -115,19 +314,72 @@ class ChatWorker(QObject):
         self._messages = messages
         self._context = context
         self._tools = tools
+        self._last_stage = "connecting"
+        self._stream_started = False
+        self._received_output = False
 
     def run(self):
         cfg = load_client_config()
         endpoint = cfg.get("endpoint")
-        if not endpoint:
-            self._fallback("No assistant endpoint configured.")
-            return
         try:
-            self._stream(cfg)
-        except Exception as e:  # network / parse failure → degrade
-            self._fallback(f"Could not reach assistant server ({e}).")
+            if not endpoint:
+                self._fallback({
+                    "level": "offline",
+                    "stage": "configuration",
+                    "component": "client",
+                    "code": "endpoint_missing",
+                    "message": "Assistant endpoint is not configured.",
+                })
+                return
+            for attempt in range(2):
+                self._last_stage = "connecting"
+                self._stream_started = False
+                try:
+                    failure = self._stream(cfg)
+                except Exception as error:
+                    failure = classify_request_failure(
+                        error,
+                        stage=self._last_stage,
+                        read_timeout=_configured_read_timeout(cfg),
+                    )
+
+                if failure is None:
+                    return
+                can_retry = (
+                    attempt == 0
+                    and not self._received_output
+                    and request_failure_is_retryable(failure)
+                )
+                if can_retry:
+                    self._emit_status({
+                        "level": "working",
+                        "stage": "retrying",
+                        "component": failure.get("component", "service"),
+                        "code": "automatic_retry",
+                        "message": (
+                            f"{failure.get('message', 'The request was interrupted')} "
+                            "Retrying automatically in 2 seconds..."
+                        ),
+                        "attempt": 2,
+                        "request_id": failure.get("request_id"),
+                    })
+                    time.sleep(2)
+                    continue
+
+                if failure.get("server_error") or self._received_output:
+                    self._emit_status(failure)
+                    self.error.emit(failure.get("message", "The assistant request failed."))
+                else:
+                    self._fallback(failure)
+                return
         finally:
             self.finished.emit()
+
+    def _emit_status(self, info: dict):
+        info = dict(info or {})
+        if info.get("stage"):
+            self._last_stage = str(info["stage"])
+        self.status.emit(info)
 
     # -- networking ---------------------------------------------------------
     def _stream(self, cfg: dict):
@@ -139,9 +391,21 @@ class ChatWorker(QObject):
         # the whole window. A warm Modal container (min_containers=1) makes 10s ample.
         timeout = cfg.get("timeout", 45)
         ct = timeout if isinstance(timeout, (tuple, list)) else (10, timeout)
+        self._emit_status({
+            "level": "working",
+            "stage": "connecting",
+            "component": "modal",
+            "message": "Connecting to Modal...",
+        })
         with requests.post(f"{cfg['endpoint']}/chat", json=payload, headers=headers,
                            stream=True, timeout=ct) as resp:
             resp.raise_for_status()
+            self._emit_status({
+                "level": "working",
+                "stage": "connected",
+                "component": "modal",
+                "message": "Modal connected. Preparing the response...",
+            })
             for raw in resp.iter_lines(decode_unicode=True):
                 if not raw:
                     continue
@@ -151,22 +415,94 @@ class ChatWorker(QObject):
                 except json.JSONDecodeError:
                     continue
                 etype = evt.get("type")
-                if etype == "token":
+                if etype == "status":
+                    if evt.get("stage") == "streaming":
+                        self._stream_started = True
+                    self._emit_status(evt)
+                elif etype == "token":
+                    self._received_output = self._received_output or bool(evt.get("text"))
+                    if not self._stream_started:
+                        self._stream_started = True
+                        local_guidance = self._last_stage == "local_guidance"
+                        self._emit_status({
+                            "level": "working",
+                            "stage": "streaming",
+                            "component": "modal" if local_guidance else "deepseek",
+                            "message": (
+                                "Receiving BEHAV3D guidance..."
+                                if local_guidance else
+                                "Receiving the assistant response..."
+                            ),
+                            "request_id": evt.get("request_id"),
+                        })
                     self.token.emit(evt.get("text", ""))
                 elif etype == "tool_calls":
+                    self._received_output = self._received_output or bool(evt.get("calls"))
+                    if not self._stream_started:
+                        self._stream_started = True
+                        self._emit_status({
+                            "level": "working",
+                            "stage": "streaming",
+                            "component": "deepseek",
+                            "message": "Receiving proposed form changes...",
+                            "request_id": evt.get("request_id"),
+                        })
                     self.tool_calls.emit(evt.get("calls", []))
                 elif etype == "error":
-                    self.error.emit(evt.get("message", "Unknown server error."))
-                    return
+                    return {
+                        "level": "error",
+                        "stage": evt.get("stage", self._last_stage),
+                        "component": evt.get("component", "server"),
+                        "code": evt.get("code", "server_error"),
+                        "message": evt.get("message", "Unknown server error."),
+                        "request_id": evt.get("request_id"),
+                        "error_type": evt.get("error_type"),
+                        "http_status": evt.get("http_status"),
+                        "server_error": True,
+                    }
                 elif etype == "done":
                     return
+            raise ConnectionError("Assistant stream ended before a done event")
 
     # -- degraded mode ------------------------------------------------------
-    def _fallback(self, reason: str):
+    def _fallback(self, reason: dict | str):
+        if isinstance(reason, str):
+            reason = {
+                "level": "offline",
+                "stage": self._last_stage,
+                "component": "unknown",
+                "code": "request_failed",
+                "message": reason,
+            }
+        self._emit_status(reason)
         user_msg = ""
         for m in reversed(self._messages):
             if m.get("role") == "user":
                 user_msg = m.get("content", "")
                 break
-        text = LocalResponder().answer(user_msg)
+        local_answer = LocalResponder().answer(user_msg)
+        text = (
+            "**Assistant offline**\n\n"
+            f"**Reason:** {reason.get('message', 'The assistant service is unavailable.')}\n\n"
+            f"{local_answer}"
+        )
         self.degraded.emit(text)
+
+
+class HealthWorker(QObject):
+    """Runs a service health check without blocking the napari GUI thread."""
+
+    result = Signal(object)
+    finished = Signal()
+
+    def __init__(self, *, probe_provider: bool = False):
+        super().__init__()
+        self._probe_provider = bool(probe_provider)
+
+    def run(self):
+        try:
+            self.result.emit(diagnose_assistant_service(
+                probe_provider=self._probe_provider
+            ))
+        finally:
+            self.finished.emit()

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -104,21 +104,27 @@ The client sends:
 `POST /chat` returns an SSE stream containing newline-delimited JSON events:
 
 ```text
+{"type":"status","stage":"retrieval","component":"retrieval","message":"...","request_id":"..."}
+{"type":"status","stage":"provider","component":"deepseek","message":"...","request_id":"..."}
 {"type":"token","text":"..."}
 {"type":"tool_calls","calls":[{"name":"set_ui_value","arguments":{...}}]}
 {"type":"done"}
 ```
 
 Failures use `{"type":"error","message":"..."}` followed by `done`.
-`GET /health` reports the active model, RAG chunk count, control contract
-version, and knowledge version.
+All events include a short `request_id` and elapsed server time. `GET /health`
+is a cheap Modal and RAG check that reports the active model, chunk count,
+control contract version, and knowledge version. `GET
+/health?probe_provider=true` also sends a one-token request to DeepSeek and
+returns its status and latency. Use the provider probe interactively or during
+diagnosis, not as a high-frequency monitor.
 
 ## Component map
 
 | File | Responsibility | Change it when |
 |---|---|---|
 | `behav3d/napari/_assistant.py` | Chat UI, quick buttons, local metadata wizard, history, streaming, action cards, no-op handling, and apply/confirm policy. | Changing the chat experience or how validated actions are presented/applied. |
-| `behav3d/napari/_assistant_client.py` | Endpoint configuration, background HTTP/SSE worker, and offline fallback. | Changing transport, timeouts, authentication, or degraded behavior. |
+| `behav3d/napari/_assistant_client.py` | Endpoint configuration, background HTTP/SSE and health workers, classified failures, automatic retry, and offline fallback. | Changing transport, timeouts, health checks, authentication, or degraded behavior. |
 | `behav3d/napari/_assistant_context.py` | Defensive serialization of live BEHAV3D state and experiment references. | The assistant needs to read a new piece of UI, metadata, log, result, or experiment state. |
 | `behav3d/napari/_assistant_controls.py` | Live editable-control registry, getters, setters, units, choices, visibility, and persistence callbacks. | The assistant should be able to inspect or edit a real UI control. |
 | `behav3d/napari/_assistant_actions.py` | Tool schemas, tool-call validation, `ProposedAction`, and action application. | Adding a new action or changing how an action is validated/applied. |
@@ -356,6 +362,43 @@ The client reads `napari/assistant_config.json`, which is gitignored. Start from
 
 `BEHAV3D_ASSISTANT_ENDPOINT` overrides the file. The timeout is split into a
 10-second connection timeout and the configured read timeout.
+
+## Runtime status and recovery
+
+The chat dock keeps a persistent service-status row above the transcript. It
+shows the current stage and elapsed time instead of a generic loading state:
+
+| UI status | What has been confirmed |
+|---|---|
+| `Connecting to Modal` | The client is opening the HTTP connection; Modal has not replied yet. |
+| `Checking BEHAV3D guidance` | Modal is online and the server is retrieving local documentation. |
+| `Waiting for DeepSeek` | Modal and retrieval are complete; the external model has not started returning data. |
+| `Receiving the response` | DeepSeek is streaming text or proposed actions. |
+| `Retrying automatically` | A transient failure occurred before any output; one safe retry is in progress. |
+| `Offline` / `Issue` | The tooltip and transcript identify Modal, DeepSeek, configuration, or the response stream as the failing component. |
+
+The **Check status** button calls the provider-probing health route and reports
+Modal, the RAG index, DeepSeek, model name, latency, and any request ID in the
+status tooltip. At startup, the client performs only the lightweight health
+check. After an outage it repeats health checks every 15 seconds and returns to
+`Online` automatically. A chat request is retried once after two seconds only
+when the failure is transient and no text or tool action has arrived; partial
+responses are never replayed, avoiding duplicate form changes.
+
+For command-line diagnosis:
+
+```bash
+# Modal and RAG only
+curl -s <url>/health
+
+# Modal, RAG, and a live DeepSeek request
+curl -s '<url>/health?probe_provider=true'
+
+# Observe request stages and retain request_id for server-log correlation
+curl -N -X POST <url>/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"Explain this screen"}],"context":{"current_step":"tracking"},"tools":[]}'
+```
 
 Run a hot-reloading Modal endpoint:
 

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -3579,6 +3579,8 @@ if modal is not None:
     @modal.asgi_app()
     def web():
         import os
+        import time
+        import uuid
         from fastapi import FastAPI, Request
         from fastapi.responses import StreamingResponse
         from openai import OpenAI
@@ -3597,14 +3599,57 @@ if modal is not None:
         # The older `deepseek-chat` alias also maps to it but is being deprecated.
         # `deepseek-v4-pro` is the stronger/pricier option. Override via DEEPSEEK_MODEL.
         deepseek_model = os.environ.get("DEEPSEEK_MODEL", "deepseek-v4-flash")
-        client = OpenAI(base_url=DEEPSEEK_BASE_URL,
-                        api_key=os.environ.get("DEEPSEEK_API_KEY", ""))
+        client = OpenAI(
+            base_url=DEEPSEEK_BASE_URL,
+            api_key=os.environ.get("DEEPSEEK_API_KEY", ""),
+            timeout=60.0,
+            max_retries=1,
+        )
 
         @api.get("/health")
-        def health():
-            return {"ok": True, "chunks": len(index.chunks), "model": deepseek_model,
-                    "control_contract_version": CONTROL_CONTRACT_VERSION,
-                    "knowledge_version": KNOWLEDGE_VERSION}
+        def health(probe_provider: bool = False):
+            retrieval_status = "ready" if len(index.chunks) else "empty"
+            provider = {"status": "not_checked"}
+            if probe_provider:
+                started = time.monotonic()
+                try:
+                    client.with_options(timeout=20.0, max_retries=0).chat.completions.create(
+                        model=deepseek_model,
+                        messages=[{
+                            "role": "user",
+                            "content": "Reply with OK.",
+                        }],
+                        temperature=0,
+                        max_tokens=1,
+                        stream=False,
+                    )
+                    provider = {
+                        "status": "online",
+                        "latency_ms": round((time.monotonic() - started) * 1000),
+                    }
+                except Exception as error:
+                    error_type = type(error).__name__
+                    print(f"DeepSeek health probe failed ({error_type}): {error}")
+                    provider = {
+                        "status": "error",
+                        "error_type": error_type,
+                        "latency_ms": round((time.monotonic() - started) * 1000),
+                    }
+
+            return {
+                "ok": retrieval_status == "ready" and provider["status"] != "error",
+                "service": {"name": "modal", "status": "online"},
+                "retrieval": {
+                    "status": retrieval_status,
+                    "chunks": len(index.chunks),
+                },
+                "provider": provider,
+                # Preserve the original top-level health contract for existing clients.
+                "chunks": len(index.chunks),
+                "model": deepseek_model,
+                "control_contract_version": CONTROL_CONTRACT_VERSION,
+                "knowledge_version": KNOWLEDGE_VERSION,
+            }
 
         @api.post("/chat")
         async def chat(request: Request):
@@ -3612,21 +3657,36 @@ if modal is not None:
             messages = body.get("messages", [])
             context = body.get("context", {})
             tools = tools_for_context(body.get("tools", []), context)
+            request_id = uuid.uuid4().hex[:12]
+            request_started = time.monotonic()
+
+            def sse(obj):
+                payload = dict(obj)
+                payload.setdefault("request_id", request_id)
+                payload.setdefault(
+                    "elapsed_ms", round((time.monotonic() - request_started) * 1000)
+                )
+                return "data: " + json.dumps(payload) + "\n\n"
 
             deterministic = deterministic_turn_response(
                 context, messages, tools
             )
             if deterministic:
                 def deterministic_action_stream():
-                    yield "data: " + json.dumps({
-                        "type": "token", "text": deterministic["text"],
-                    }) + "\n\n"
+                    yield sse({
+                        "type": "status",
+                        "level": "working",
+                        "stage": "local_guidance",
+                        "component": "modal",
+                        "message": "Using the current BEHAV3D state...",
+                    })
+                    yield sse({"type": "token", "text": deterministic["text"]})
                     if deterministic.get("calls"):
-                        yield "data: " + json.dumps({
+                        yield sse({
                             "type": "tool_calls",
                             "calls": deterministic["calls"],
-                        }) + "\n\n"
-                    yield "data: " + json.dumps({"type": "done"}) + "\n\n"
+                        })
+                    yield sse({"type": "done"})
 
                 return StreamingResponse(
                     deterministic_action_stream(), media_type="text/event-stream"
@@ -3637,34 +3697,62 @@ if modal is not None:
             force_bulk = should_force_bulk_metadata(context, user_msg, tools)
             if force_bulk:
                 tools = [tool for tool in tools if tool.get("name") == "bulk_fill_metadata"]
-            query = f"{context.get('current_step','')} {user_msg}"
-            try:
-                retrieved = index.search(embedder.encode([query])[0], k=6)
-            except Exception:
-                retrieved = []
-
-            intent = (context.get("assistant_session", {}) or {}).get("intent")
-            deterministic = select_guidance_cards(context, user_msg, intent)
-            retrieved = deterministic + retrieved
-
-            system = build_system_prompt(context, retrieved, tools)
-            convo = [{"role": "system", "content": system}]
-            convo += [m for m in messages if m.get("role") != "system"]
-            control_ids = [item.get("id") for item in
-                           (context.get("ui_state", {}) or {}).get("controls", [])
-                           if item.get("id") and item.get("enabled") and item.get("visible")]
-            oai_tools = to_openai_tools(tools, key_enum=control_ids)
-            tool_choice, thinking_override = model_tool_policy(
-                force_bulk, bool(oai_tools)
-            )
-
-            def sse(obj):
-                return "data: " + json.dumps(obj) + "\n\n"
 
             def event_stream():
                 content = ""
                 visible_buffer = ""
                 tool_frags = []
+                yield sse({
+                    "type": "status",
+                    "level": "working",
+                    "stage": "retrieval",
+                    "component": "retrieval",
+                    "message": "Checking BEHAV3D guidance for this question...",
+                })
+
+                query = f"{context.get('current_step','')} {user_msg}"
+                try:
+                    retrieved = index.search(embedder.encode([query])[0], k=6)
+                except Exception as error:
+                    print(f"RAG retrieval failed for {request_id} ({type(error).__name__}): {error}")
+                    retrieved = []
+                    yield sse({
+                        "type": "status",
+                        "level": "degraded",
+                        "stage": "retrieval",
+                        "component": "retrieval",
+                        "code": "retrieval_unavailable",
+                        "message": (
+                            "The BEHAV3D guidance search is unavailable; continuing with "
+                            "built-in guidance."
+                        ),
+                    })
+
+                intent = (context.get("assistant_session", {}) or {}).get("intent")
+                guidance_cards = select_guidance_cards(context, user_msg, intent)
+                retrieved = guidance_cards + retrieved
+                system = build_system_prompt(context, retrieved, tools)
+                convo = [{"role": "system", "content": system}]
+                convo += [m for m in messages if m.get("role") != "system"]
+                control_ids = [
+                    item.get("id")
+                    for item in (context.get("ui_state", {}) or {}).get("controls", [])
+                    if item.get("id") and item.get("enabled") and item.get("visible")
+                ]
+                oai_tools = to_openai_tools(tools, key_enum=control_ids)
+                tool_choice, thinking_override = model_tool_policy(
+                    force_bulk, bool(oai_tools)
+                )
+
+                yield sse({
+                    "type": "status",
+                    "level": "working",
+                    "stage": "provider",
+                    "component": "deepseek",
+                    "message": "Waiting for DeepSeek...",
+                })
+                provider_started = time.monotonic()
+                response_started = False
                 try:
                     request_options = {
                         "model": deepseek_model,
@@ -3681,6 +3769,18 @@ if modal is not None:
                         **request_options
                     )
                     for chunk in stream:
+                        if not response_started:
+                            response_started = True
+                            yield sse({
+                                "type": "status",
+                                "level": "working",
+                                "stage": "streaming",
+                                "component": "deepseek",
+                                "message": "Receiving the response from DeepSeek...",
+                                "provider_latency_ms": round(
+                                    (time.monotonic() - provider_started) * 1000
+                                ),
+                            })
                         delta = chunk.choices[0].delta
                         if getattr(delta, "content", None):
                             content += delta.content
@@ -3698,7 +3798,22 @@ if modal is not None:
                                 "arguments": getattr(fn, "arguments", None) if fn else None,
                             })
                 except Exception as e:
-                    yield sse({"type": "error", "message": f"DeepSeek API error: {e}"})
+                    error_type = type(e).__name__
+                    is_timeout = "timeout" in error_type.lower()
+                    print(f"DeepSeek request failed for {request_id} ({error_type}): {e}")
+                    yield sse({
+                        "type": "error",
+                        "stage": "provider",
+                        "component": "deepseek",
+                        "code": "deepseek_timeout" if is_timeout else "provider_error",
+                        "error_type": error_type,
+                        "retryable": True,
+                        "message": (
+                            "DeepSeek timed out before completing the response. Modal is online."
+                            if is_timeout else
+                            "DeepSeek could not generate a response. Modal is online."
+                        ),
+                    })
                     yield sse({"type": "done"})
                     return
 

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -36,6 +36,10 @@ from behav3d.napari._assistant_recommendations import (
 from behav3d.napari._assistant import (
     researcher_facing_text, streaming_transcript_block, transcript_block_role,
 )
+from behav3d.napari._assistant_client import (
+    ChatWorker, classify_request_failure, diagnose_assistant_service,
+    request_failure_is_retryable,
+)
 from behav3d.analysis.track_counts import (
     calculate_track_count_table, format_track_count_summary,
     generate_track_count_summary,
@@ -1127,6 +1131,130 @@ def test_chat_transcript_shows_waiting_block_and_tracks_role_colors():
         "**BEHAV3D Assistant**\n\n*Preparing a response...*"
     )
     assert streaming_transcript_block(False, None) is None
+
+
+def test_chat_transcript_waiting_block_shows_current_service_stage():
+    assert streaming_transcript_block(
+        True, "", "Waiting for DeepSeek..."
+    ) == "**BEHAV3D Assistant**\n\n*Waiting for DeepSeek...*"
+
+
+def test_request_failures_identify_modal_and_deepseek_separately():
+    ConnectTimeout = type("ConnectTimeout", (Exception,), {})
+    ReadTimeout = type("ReadTimeout", (Exception,), {})
+
+    modal = classify_request_failure(ConnectTimeout(), stage="connecting")
+    assert modal["component"] == "modal"
+    assert modal["code"] == "modal_connect_timeout"
+    assert request_failure_is_retryable(modal)
+
+    provider = classify_request_failure(
+        ReadTimeout(), stage="provider", read_timeout=60
+    )
+    assert provider["component"] == "deepseek"
+    assert provider["code"] == "deepseek_timeout"
+    assert "Modal is reachable" in provider["message"]
+    assert request_failure_is_retryable(provider)
+
+
+def test_health_diagnostic_maps_modal_rag_and_provider_status():
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "ok": True,
+                "service": {"status": "online"},
+                "retrieval": {"status": "ready", "chunks": 971},
+                "provider": {"status": "online", "latency_ms": 120},
+                "model": "deepseek-v4-flash",
+                "knowledge_version": "test-version",
+            }
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return Response()
+
+    result = diagnose_assistant_service(
+        {"endpoint": "https://assistant.test", "timeout": 60},
+        probe_provider=True,
+        requester=fake_get,
+    )
+    assert calls[0][0] == "https://assistant.test/health"
+    assert calls[0][1]["params"] == {"probe_provider": "true"}
+    assert result["level"] == "online"
+    assert result["modal"] == "online"
+    assert result["retrieval"] == "ready"
+    assert result["deepseek"] == "online"
+    assert result["chunks"] == 971
+
+
+def test_health_diagnostic_explains_missing_endpoint():
+    result = diagnose_assistant_service({"endpoint": "", "timeout": 60})
+    assert result["level"] == "offline"
+    assert result["code"] == "endpoint_missing"
+    assert result["deepseek"] == "not_checked"
+
+
+def test_chat_worker_retries_transient_failure_once_before_output():
+    from unittest.mock import patch
+
+    class RetryWorker(ChatWorker):
+        def __init__(self):
+            super().__init__(messages=[], context={}, tools=[])
+            self.attempts = 0
+
+        def _stream(self, cfg):
+            self.attempts += 1
+            if self.attempts == 1:
+                return {
+                    "level": "offline",
+                    "component": "modal",
+                    "code": "modal_unreachable",
+                    "message": "Modal is temporarily unavailable.",
+                }
+            return None
+
+    worker = RetryWorker()
+    statuses = []
+    finished = []
+    worker.status.connect(statuses.append)
+    worker.finished.connect(lambda: finished.append(True))
+    with patch(
+        "behav3d.napari._assistant_client.load_client_config",
+        return_value={"endpoint": "https://assistant.test", "timeout": 60},
+    ), patch("behav3d.napari._assistant_client.time.sleep"):
+        worker.run()
+
+    assert worker.attempts == 2
+    assert any(status.get("code") == "automatic_retry" for status in statuses)
+    assert finished == [True]
+
+
+def test_chat_worker_offline_fallback_keeps_reason_and_always_finishes():
+    from unittest.mock import patch
+
+    worker = ChatWorker(
+        messages=[{"role": "user", "content": "What does search range mean?"}],
+        context={},
+        tools=[],
+    )
+    degraded = []
+    finished = []
+    worker.degraded.connect(degraded.append)
+    worker.finished.connect(lambda: finished.append(True))
+    with patch(
+        "behav3d.napari._assistant_client.load_client_config",
+        return_value={"endpoint": "", "timeout": 60},
+    ):
+        worker.run()
+
+    assert "Assistant endpoint is not configured" in degraded[0]
+    assert "local parameter reference" in degraded[0]
+    assert finished == [True]
     role = transcript_block_role("You")
     assert role == "user"
     assert transcript_block_role("My question", role) == "user"


### PR DESCRIPTION
## Summary

- Add a persistent assistant status row with stage-specific progress and elapsed time for Modal connection, BEHAV3D guidance retrieval, DeepSeek waiting, and response streaming.
- Add a **Check status** action that diagnoses Modal, the RAG index, and DeepSeek, including model/provider latency and request IDs in the status details.
- Extend `/health` with structured service/retrieval/provider fields and an optional `probe_provider=true` live DeepSeek check while preserving the original top-level contract.
- Add structured SSE status events and request IDs to both deterministic and model-backed responses.
- Classify connection, HTTP, timeout, provider, and malformed-response failures instead of collapsing them into a generic offline mode.
- Retry transient failures once when no output has arrived, then perform 15-second background health checks after an outage so the UI recovers automatically.
- Preserve the actual failure reason in local fallback responses and guarantee the worker always leaves the loading state, including when no endpoint is configured.
- Document the status protocol, health routes, troubleshooting flow, and retry guarantees.

## Root cause

The client caught all transport failures in one broad exception path and discarded the reason before rendering the offline fallback. The server emitted only content/action/completion events, so connection startup, retrieval, and DeepSeek latency all appeared as the same generic loading state. The existing health route also confirmed only that Modal was reachable; it did not distinguish the RAG index from the external model provider, and neither layer attempted recovery.

## Compatibility

The API change is additive. Existing `dev` clients continue to use the same request payload and `token`, `tool_calls`, `error`, and `done` events while ignoring the new `status` event type. The original `/health` fields (`ok`, `chunks`, `model`, `control_contract_version`, and `knowledge_version`) remain present.

## Verification

- `110/110` assistant regression tests pass.
- Python compilation and `git diff --check` pass.
- Deployed the updated Modal service at `https://ojh22--behav3d-assistant-web.modal.run`.
- Lightweight health check reports Modal online and 971 RAG chunks.
- Provider health probe reports DeepSeek online and returns provider latency.
- Live model request emitted `retrieval -> provider -> streaming -> done` under one request ID.
- Live deterministic request emitted `local_guidance -> token -> done` under one request ID.
- The actual napari `ChatWorker` parsed the deployed stream, produced text, emitted all expected stages, completed its signal lifecycle, and reported no errors.
