### PR TITLE
Make assistant progress copy provider-neutral

### DIFF
--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -372,8 +372,8 @@ shows the current stage and elapsed time instead of a generic loading state:
 |---|---|
 | `Connecting to Modal` | The client is opening the HTTP connection; Modal has not replied yet. |
 | `Checking BEHAV3D guidance` | Modal is online and the server is retrieving local documentation. |
-| `Waiting for DeepSeek` | Modal and retrieval are complete; the external model has not started returning data. |
-| `Receiving the response` | DeepSeek is streaming text or proposed actions. |
+| `Waiting for response` | The service is ready, but the response has not started returning yet. |
+| `Receiving response` | Text or proposed actions are streaming to the application. |
 | `Retrying automatically` | A transient failure occurred before any output; one safe retry is in progress. |
 | `Offline` / `Issue` | The tooltip and transcript identify Modal, DeepSeek, configuration, or the response stream as the failing component. |
 

--- a/chatbot/app.py
+++ b/chatbot/app.py
@@ -3749,7 +3749,7 @@ if modal is not None:
                     "level": "working",
                     "stage": "provider",
                     "component": "deepseek",
-                    "message": "Waiting for DeepSeek...",
+                    "message": "Waiting for response...",
                 })
                 provider_started = time.monotonic()
                 response_started = False
@@ -3776,7 +3776,7 @@ if modal is not None:
                                 "level": "working",
                                 "stage": "streaming",
                                 "component": "deepseek",
-                                "message": "Receiving the response from DeepSeek...",
+                                "message": "Receiving response...",
                                 "provider_latency_ms": round(
                                     (time.monotonic() - provider_started) * 1000
                                 ),

--- a/test/test_assistant.py
+++ b/test/test_assistant.py
@@ -1135,8 +1135,8 @@ def test_chat_transcript_shows_waiting_block_and_tracks_role_colors():
 
 def test_chat_transcript_waiting_block_shows_current_service_stage():
     assert streaming_transcript_block(
-        True, "", "Waiting for DeepSeek..."
-    ) == "**BEHAV3D Assistant**\n\n*Waiting for DeepSeek...*"
+        True, "", "Waiting for response..."
+    ) == "**BEHAV3D Assistant**\n\n*Waiting for response...*"
 
 
 def test_request_failures_identify_modal_and_deepseek_separately():


### PR DESCRIPTION
## Summary

- Change the assistant progress message from `Waiting for DeepSeek...` to `Waiting for response...`.
- Change `Receiving the response from DeepSeek...` to `Receiving response...`.
- Update the documented UI states and regression expectation to match.

## Why

The model provider is an implementation detail that does not help researchers while a normal response is in progress. Provider names remain available in diagnostics and provider-specific error messages, where they are useful for troubleshooting.

## Verification

- All 110 assistant regression tests pass.
- Python compilation and `git diff --check` pass.
- Deployed the updated Modal service.
- Confirmed the live stream now emits `Waiting for response...` and `Receiving response...`.
